### PR TITLE
Cumulative time limit (issue #5)

### DIFF
--- a/client/src/components/admin/ResultForm/ResultForm.js
+++ b/client/src/components/admin/ResultForm/ResultForm.js
@@ -121,9 +121,29 @@ const ResultForm = ({
             initialValue={attempt}
             disabled={!result || index >= disabledFromIndex}
             onValue={value => {
-              const updatedValue =
-                timeLimit && value >= timeLimit.centiseconds ? -1 : value;
-              const updatedAttempts = setAt(attempts, index, updatedValue);
+              var updatedAttempts = setAt(attempts, index, value);
+              if (timeLimit) {
+                if (timeLimit.cumulativeRoundIds.length === 1) {
+                  var totalTime = 0,
+                    i;
+                  for (i = 0; i < updatedAttempts.length; i++) {
+                    if (updatedAttempts[i] > 0) {
+                      totalTime += updatedAttempts[i];
+                      if (totalTime >= timeLimit.centiseconds) {
+                        updatedAttempts[i] = -1;
+                        break;
+                      }
+                    }
+                  }
+                  for (; i < updatedAttempts.length; i++) {
+                    if (updatedAttempts[i] > 0) {
+                      updatedAttempts[i] = -1;
+                    }
+                  }
+                } else if (value >= timeLimit.centiseconds) {
+                  updatedAttempts[index] = -1;
+                }
+              }
               setAttempts(
                 meetsCutoff(updatedAttempts, cutoff, eventId)
                   ? updatedAttempts

--- a/client/src/components/admin/ResultForm/ResultForm.js
+++ b/client/src/components/admin/ResultForm/ResultForm.js
@@ -16,7 +16,7 @@ import {
   formatAttemptResult,
   attemptsWarning,
   applyTimeLimit,
-  applyCutOff,
+  applyCutoff,
 } from '../../../logic/attempts';
 import { best, average } from '../../../logic/stats';
 import { cutoffToString, timeLimitToString } from '../../../logic/formatters';
@@ -64,7 +64,7 @@ const ResultForm = ({
 
   const submissionWarning = attemptsWarning(attempts, eventId);
 
-  const disabledFromIndex = meetsCutoff(attempts, cutoff, eventId)
+  const disabledFromIndex = meetsCutoff(attempts, cutoff)
     ? solveCount
     : cutoff.numberOfAttempts;
 
@@ -124,9 +124,9 @@ const ResultForm = ({
             disabled={!result || index >= disabledFromIndex}
             onValue={value => {
               setAttempts(
-                applyTimeLimit(
-                  applyCutOff(setAt(attempts, index, value), cutoff, eventId),
-                  timeLimit
+                applyCutoff(
+                  applyTimeLimit(setAt(attempts, index, value), timeLimit),
+                  cutoff
                 )
               );
             }}

--- a/client/src/components/admin/ResultForm/ResultForm.js
+++ b/client/src/components/admin/ResultForm/ResultForm.js
@@ -15,6 +15,8 @@ import {
   meetsCutoff,
   formatAttemptResult,
   attemptsWarning,
+  applyTimeLimit,
+  applyCutOff,
 } from '../../../logic/attempts';
 import { best, average } from '../../../logic/stats';
 import { cutoffToString, timeLimitToString } from '../../../logic/formatters';
@@ -121,35 +123,11 @@ const ResultForm = ({
             initialValue={attempt}
             disabled={!result || index >= disabledFromIndex}
             onValue={value => {
-              var updatedAttempts = setAt(attempts, index, value);
-              if (timeLimit) {
-                if (timeLimit.cumulativeRoundIds.length === 1) {
-                  var totalTime = 0,
-                    i;
-                  for (i = 0; i < updatedAttempts.length; i++) {
-                    if (updatedAttempts[i] > 0) {
-                      totalTime += updatedAttempts[i];
-                      if (totalTime >= timeLimit.centiseconds) {
-                        updatedAttempts[i] = -1;
-                        break;
-                      }
-                    }
-                  }
-                  for (; i < updatedAttempts.length; i++) {
-                    if (updatedAttempts[i] > 0) {
-                      updatedAttempts[i] = -1;
-                    }
-                  }
-                } else if (value >= timeLimit.centiseconds) {
-                  updatedAttempts[index] = -1;
-                }
-              }
               setAttempts(
-                meetsCutoff(updatedAttempts, cutoff, eventId)
-                  ? updatedAttempts
-                  : updatedAttempts.map((attempt, index) =>
-                      index < cutoff.numberOfAttempts ? attempt : 0
-                    )
+                applyTimeLimit(
+                  applyCutOff(setAt(attempts, index, value), cutoff, eventId),
+                  timeLimit
+                )
               );
             }}
           />

--- a/client/src/logic/attempts.js
+++ b/client/src/logic/attempts.js
@@ -125,3 +125,32 @@ export const attemptsWarning = (attempts, eventId) => {
   }
   return null;
 };
+
+export const applyTimeLimit = (attempts, timeLimit) => {
+  if (timeLimit.cumulativeRoundIds.length === 0) {
+    return attempts.map(attempt =>
+      attempt >= timeLimit.centiseconds ? -1 : attempt
+    );
+  } else {
+    /* Note: for now cross-round cumulative time limits are handled
+       as single-round cumulative time limits for each of the rounds. */
+    const [updatedAttempts, sum] = attempts.reduce(
+      ([updatedAttempts, sum], attempt) => {
+        const updatedSum = attempt > 0 ? sum + attempt : sum;
+        const updatedAttempt =
+          attempt > 0 && updatedSum >= timeLimit.centiseconds ? -1 : attempt;
+        return [updatedAttempts.concat(updatedAttempt), updatedSum];
+      },
+      [[], 0]
+    );
+    return updatedAttempts;
+  }
+};
+
+export const applyCutOff = (attempts, cutoff, eventId) => {
+  return meetsCutoff(attempts, cutoff, eventId)
+    ? attempts
+    : attempts.map((attempt, index) =>
+        index < cutoff.numberOfAttempts ? attempt : 0
+      );
+};

--- a/client/src/logic/attempts.js
+++ b/client/src/logic/attempts.js
@@ -147,8 +147,8 @@ export const applyTimeLimit = (attempts, timeLimit) => {
   }
 };
 
-export const applyCutOff = (attempts, cutoff, eventId) => {
-  return meetsCutoff(attempts, cutoff, eventId)
+export const applyCutoff = (attempts, cutoff) => {
+  return meetsCutoff(attempts, cutoff)
     ? attempts
     : attempts.map((attempt, index) =>
         index < cutoff.numberOfAttempts ? attempt : 0

--- a/client/src/logic/tests/attempts.test.js
+++ b/client/src/logic/tests/attempts.test.js
@@ -5,7 +5,7 @@ import {
   meetsCutoff,
   attemptsWarning,
   applyTimeLimit,
-  applyCutOff,
+  applyCutoff,
 } from '../attempts';
 
 describe('formatAttemptResult', () => {
@@ -225,7 +225,7 @@ describe('applyTimeLimit', () => {
     ]);
   });
 
-  it('3th attempt becomes DNF because of exceeding cumulative time limit', () => {
+  it('3rd attempt becomes DNF because of exceeding cumulative time limit', () => {
     const attempts = [3000, 13000, 5000];
     const timeLimit = {
       cumulativeRoundIds: ['333bf'],
@@ -235,15 +235,15 @@ describe('applyTimeLimit', () => {
   });
 });
 
-describe('applyCutOff', () => {
-  it('3rd attempt becomes empty because the first two attempts did not meet cutoff', () => {
+describe('applyCutoff', () => {
+  it('3rd attempt becomes skipped because the first two attempts did not meet cutoff', () => {
     const attempts = [1000, 1100, 1200, 0, 0];
     const cutoff = {
       numberOfAttempts: 2,
       attemptResult: 800,
     };
     const eventId = '333bf';
-    expect(applyCutOff(attempts, cutoff, eventId)).toEqual([
+    expect(applyCutoff(attempts, cutoff, eventId)).toEqual([
       1000,
       1100,
       0,

--- a/client/src/logic/tests/attempts.test.js
+++ b/client/src/logic/tests/attempts.test.js
@@ -4,6 +4,8 @@ import {
   validateMbldAttempt,
   meetsCutoff,
   attemptsWarning,
+  applyTimeLimit,
+  applyCutOff,
 } from '../attempts';
 
 describe('formatAttemptResult', () => {
@@ -204,5 +206,49 @@ describe('attemptsWarning', () => {
   it('doas not treat trailing skipped attempts as omitted', () => {
     const attempts = [1000, 0, 0];
     expect(attemptsWarning(attempts, '333')).toEqual(null);
+  });
+});
+
+describe('applyTimeLimit', () => {
+  it('4th attempt becomes DNF because of exceeding time limit', () => {
+    const attempts = [1000, 1100, 1200, 1300, 0];
+    const timeLimit = {
+      cumulativeRoundIds: [],
+      centiseconds: 1250,
+    };
+    expect(applyTimeLimit(attempts, timeLimit)).toEqual([
+      1000,
+      1100,
+      1200,
+      -1,
+      0,
+    ]);
+  });
+
+  it('3th attempt becomes DNF because of exceeding cumulative time limit', () => {
+    const attempts = [3000, 13000, 5000];
+    const timeLimit = {
+      cumulativeRoundIds: ['333bf'],
+      centiseconds: 20000,
+    };
+    expect(applyTimeLimit(attempts, timeLimit)).toEqual([3000, 13000, -1]);
+  });
+});
+
+describe('applyCutOff', () => {
+  it('3rd attempt becomes empty because the first two attempts did not meet cutoff', () => {
+    const attempts = [1000, 1100, 1200, 0, 0];
+    const cutoff = {
+      numberOfAttempts: 2,
+      attemptResult: 800,
+    };
+    const eventId = '333bf';
+    expect(applyCutOff(attempts, cutoff, eventId)).toEqual([
+      1000,
+      1100,
+      0,
+      0,
+      0,
+    ]);
   });
 });


### PR DESCRIPTION
Just like converting the attempt to DNF, this will convert the last time(s) to DNF if cumulative time limit is crossed. This will allow the delegate to know while data entry that cumulative time limit is exceeded.