### PR TITLE
Restrict synchronization to competition managers

### DIFF
--- a/client/src/components/Error/Error.js
+++ b/client/src/components/Error/Error.js
@@ -7,7 +7,7 @@ function Error({ error = null }) {
   const message = apolloErrorToMessage(error);
 
   return (
-    <Box sx={{ width: '100%' }}>
+    <Box sx={{ width: '100%', py: 4 }}>
       <Grid container direction="column" spacing={2} alignItems="center">
         <Grid item>
           <Typography variant="h5">Oh dear!</Typography>
@@ -16,7 +16,7 @@ function Error({ error = null }) {
           <Box
             component="img"
             src={errorImage}
-            height="300"
+            height={300}
             alt="error"
             sx={{ maxWidth: '100%' }}
           />

--- a/client/src/components/admin/AdminCompetitionNavigation/AdminCompetitionNavigation.js
+++ b/client/src/components/admin/AdminCompetitionNavigation/AdminCompetitionNavigation.js
@@ -41,7 +41,9 @@ function AdminCompetitionNavigation() {
     <AdminCompetitionLayout competition={competition}>
       <Routes>
         <Route path="" element={<AdminCompetitionEvents />} />
-        <Route path="sync" element={<Synchronization />} />
+        {competition.access.canManage && (
+          <Route path="sync" element={<Synchronization />} />
+        )}
         {competition.access.canManage && (
           <Route path="settings" element={<AdminSettings />} />
         )}

--- a/client/src/components/admin/AdminCompetitionNavigation/AdminCompetitionToolbar.js
+++ b/client/src/components/admin/AdminCompetitionNavigation/AdminCompetitionToolbar.js
@@ -45,16 +45,18 @@ function AdminCompetitionToolbar({ competition }) {
           <ViewListIcon />
         </IconButton>
       </Tooltip>
-      <Tooltip title="Synchronization">
-        <IconButton
-          color="inherit"
-          component={RouterLink}
-          to={`/admin/competitions/${competition.id}/sync`}
-          size="large"
-        >
-          <SyncIcon />
-        </IconButton>
-      </Tooltip>
+      {competition.access.canManage && (
+        <Tooltip title="Synchronization">
+          <IconButton
+            color="inherit"
+            component={RouterLink}
+            to={`/admin/competitions/${competition.id}/sync`}
+            size="large"
+          >
+            <SyncIcon />
+          </IconButton>
+        </Tooltip>
+      )}
       <Tooltip title="Competitors">
         <IconButton
           color="inherit"

--- a/server/lib/wca_live/accounts.ex
+++ b/server/lib/wca_live/accounts.ex
@@ -71,7 +71,7 @@ defmodule WcaLive.Accounts do
         {:ok, new_access_token}
       else
         {:error, _} ->
-          {:error, "failed to refresh access token"}
+          {:error, "failed to refresh access token, please try to sign out and in"}
       end
     else
       {:ok, access_token}

--- a/server/lib/wca_live_web/resolvers/synchronization_mutation.ex
+++ b/server/lib/wca_live_web/resolvers/synchronization_mutation.ex
@@ -1,7 +1,6 @@
 defmodule WcaLiveWeb.Resolvers.SynchronizationMutation do
   alias WcaLive.Competitions
   alias WcaLive.Synchronization
-  alias WcaLive.Scoretaking
 
   def import_competition(_parent, %{input: input}, %{context: %{current_user: current_user}}) do
     with {:ok, competition} <- Synchronization.import_competition(input.wca_id, current_user) do
@@ -14,9 +13,9 @@ defmodule WcaLiveWeb.Resolvers.SynchronizationMutation do
   def synchronize_competition(_parent, %{input: input}, %{context: %{current_user: current_user}}) do
     with {:ok, competition} <- Competitions.fetch_competition(input.id),
          true <-
-           Scoretaking.Access.can_scoretake_competition?(current_user, competition) ||
+           Competitions.Access.can_manage_competition?(current_user, competition) ||
              {:error, "access denied"},
-         {:ok, competition} <- Synchronization.synchronize_competition(competition) do
+         {:ok, competition} <- Synchronization.synchronize_competition(competition, current_user) do
       {:ok, %{competition: competition}}
     end
   end


### PR DESCRIPTION
So far regular scoretakers could hit the "Synchronize" button, but technically they don't have the necessary WCA access to do that, so we always performed the synchronization as whoever imported the competition. This caused issues if refreshing the WCA access token for that user failed and the only way to fix that was for that specific user to sign in and out. This change restricts synchronization to competition organizers/delegates/admins and always uses the credential of whoever does the synchronization.

In retrospect, I can't think of a good reason to allow scoretakers synchronize the results in the first place. It's definitely fine for them to do it, but the synchronization is always done before using another tool like Groupifier or Scrambles Matcher and scoretakers cannot access any of those anyway.