### PR TITLE
Correctly display tied records

### DIFF
--- a/server/test/wca_live/scoretaking_test.exs
+++ b/server/test/wca_live/scoretaking_test.exs
@@ -522,7 +522,10 @@ defmodule WcaLive.ScoretakingTest do
       person: build(:person, country_iso2: "GB")
     )
 
-    assert 2 = length(Scoretaking.list_recent_records())
+    records = Scoretaking.list_recent_records()
+
+    assert 2 = length(records)
+    assert 2 = records |> Enum.uniq_by(& &1.id) |> length()
   end
 
   test "list_podiums/1 returns one podium object for each final round" do


### PR DESCRIPTION
Closes #86.

We computed record ids like `333#single#WR`, so there would be duplicate ids for tied records and Apollo uses id for storing objects in cache, so we would get the same object twice.