### PR TITLE
Advancing when round is in progress: don't take the no-shows into account. Fixes #109

### DIFF
--- a/server/lib/wca_live/scoretaking/advancing.ex
+++ b/server/lib/wca_live/scoretaking/advancing.ex
@@ -67,11 +67,16 @@ defmodule WcaLive.Scoretaking.Advancing do
         %{results: results, advancement_condition: advancement_condition} = round
         format = Format.get_by_id!(round.format_id)
 
+        # We ignore unranked results until they are entered. For percentage-based
+        # advancement rules this means that we qualify less results initially and
+        # start qualifying more as the missing results are entered. This way, in
+        # case the remaining missing results are quit, we don't un-qualify anyone
+        results = Enum.filter(results, & &1.ranking)
+
         # See: https://www.worldcubeassociation.org/regulations/#9p1
         max_qualifying = floor(length(results) * 0.75)
-        rankings = Enum.filter(results, fn result ->
-          result.best != nil
-        end) |> Enum.map(& &1.ranking) |> Enum.reject(&is_nil/1) |> Enum.sort()
+
+        rankings = results |> Enum.map(& &1.ranking) |> Enum.sort()
 
         first_non_qualifying_ranking =
           if length(rankings) > max_qualifying do
@@ -183,12 +188,12 @@ defmodule WcaLive.Scoretaking.Advancing do
   end
 
   defp qualifying_results_ignoring(round, ignored_results) do
-    # Empty attempts rank ignored people at the end (making sure they don't qualify).
+    # DNF attempts rank ignored people at the end (making sure they don't qualify).
     # Then recompute rankings and see who would qualify as a result.
     hypothetical_results =
       Enum.map(round.results, fn result ->
         if result in ignored_results do
-          %{result | attempts: [], best: 0, average: 0}
+          %{result | attempts: [-1], best: -1, average: -1}
         else
           result
         end

--- a/server/lib/wca_live/scoretaking/advancing.ex
+++ b/server/lib/wca_live/scoretaking/advancing.ex
@@ -69,7 +69,9 @@ defmodule WcaLive.Scoretaking.Advancing do
 
         # See: https://www.worldcubeassociation.org/regulations/#9p1
         max_qualifying = floor(length(results) * 0.75)
-        rankings = results |> Enum.map(& &1.ranking) |> Enum.reject(&is_nil/1) |> Enum.sort()
+        rankings = Enum.filter(results, fn result ->
+          result.best != nil
+        end) |> Enum.map(& &1.ranking) |> Enum.reject(&is_nil/1) |> Enum.sort()
 
         first_non_qualifying_ranking =
           if length(rankings) > max_qualifying do

--- a/server/test/wca_live/scoretaking/advancing_test.exs
+++ b/server/test/wca_live/scoretaking/advancing_test.exs
@@ -15,10 +15,10 @@ defmodule WcaLive.Scoretaking.AdvancingTest do
         advancement_condition: %{type: "ranking", level: 3}
       )
 
-    result1 = insert(:result, round: round1, ranking: 1, advancing: false)
-    result2 = insert(:result, round: round1, ranking: 2, advancing: false)
-    result3 = insert(:result, round: round1, ranking: 3, advancing: false)
-    result4 = insert(:result, round: round1, ranking: 4, advancing: false)
+    result1 = insert(:result, round: round1, ranking: 1, best: 1000, advancing: false)
+    result2 = insert(:result, round: round1, ranking: 2, best: 1100, advancing: false)
+    result3 = insert(:result, round: round1, ranking: 3, best: 1200, advancing: false)
+    result4 = insert(:result, round: round1, ranking: 4, best: 1300, advancing: false)
 
     round2 =
       insert(:round, competition_event: competition_event, number: 2, advancement_condition: nil)
@@ -50,10 +50,10 @@ defmodule WcaLive.Scoretaking.AdvancingTest do
         advancement_condition: %{type: "ranking", level: 3}
       )
 
-    result1 = insert(:result, round: round1, ranking: 1, advancing: false)
-    result2 = insert(:result, round: round1, ranking: 2, advancing: false)
-    result3 = insert(:result, round: round1, ranking: 3, advancing: false)
-    result4 = insert(:result, round: round1, ranking: 4, advancing: false)
+    result1 = insert(:result, round: round1, ranking: 1, best: 1000, advancing: false)
+    result2 = insert(:result, round: round1, ranking: 2, best: 1100, advancing: false)
+    result3 = insert(:result, round: round1, ranking: 3, best: 1200, advancing: false)
+    result4 = insert(:result, round: round1, ranking: 4, best: 1300, advancing: false)
 
     _round2 =
       insert(:round, competition_event: competition_event, number: 2, advancement_condition: nil)
@@ -100,6 +100,18 @@ defmodule WcaLive.Scoretaking.AdvancingTest do
     _result3 = insert(:result, round: round, ranking: 3)
     _result4 = insert(:result, round: round, ranking: 4)
     _result5 = insert(:result, round: round, ranking: 5)
+
+    assert ids([result1, result2]) == ids(Advancing.qualifying_results(round))
+  end
+
+  test "qualifying_results/1 given `percent` advancement condition, ignores results that are not entered yet" do
+    round = insert(:round, number: 1, advancement_condition: %{type: "percent", level: 50})
+    result1 = insert(:result, round: round, ranking: 1, best: 1000)
+    result2 = insert(:result, round: round, ranking: 2, best: 1100)
+    _result3 = insert(:result, round: round, ranking: 3, best: 1200)
+    _result4 = insert(:result, round: round, ranking: 4, best: 1400)
+    _result5 = insert(:result, round: round, ranking: 5)
+    _result6 = insert(:result, round: round, ranking: 6)
 
     assert ids([result1, result2]) == ids(Advancing.qualifying_results(round))
   end

--- a/server/test/wca_live/scoretaking/advancing_test.exs
+++ b/server/test/wca_live/scoretaking/advancing_test.exs
@@ -15,10 +15,10 @@ defmodule WcaLive.Scoretaking.AdvancingTest do
         advancement_condition: %{type: "ranking", level: 3}
       )
 
-    result1 = insert(:result, round: round1, ranking: 1, best: 1000, advancing: false)
-    result2 = insert(:result, round: round1, ranking: 2, best: 1100, advancing: false)
-    result3 = insert(:result, round: round1, ranking: 3, best: 1200, advancing: false)
-    result4 = insert(:result, round: round1, ranking: 4, best: 1300, advancing: false)
+    result1 = insert(:result, round: round1, ranking: 1, advancing: false)
+    result2 = insert(:result, round: round1, ranking: 2, advancing: false)
+    result3 = insert(:result, round: round1, ranking: 3, advancing: false)
+    result4 = insert(:result, round: round1, ranking: 4, advancing: false)
 
     round2 =
       insert(:round, competition_event: competition_event, number: 2, advancement_condition: nil)
@@ -50,10 +50,10 @@ defmodule WcaLive.Scoretaking.AdvancingTest do
         advancement_condition: %{type: "ranking", level: 3}
       )
 
-    result1 = insert(:result, round: round1, ranking: 1, best: 1000, advancing: false)
-    result2 = insert(:result, round: round1, ranking: 2, best: 1100, advancing: false)
-    result3 = insert(:result, round: round1, ranking: 3, best: 1200, advancing: false)
-    result4 = insert(:result, round: round1, ranking: 4, best: 1300, advancing: false)
+    result1 = insert(:result, round: round1, ranking: 1, advancing: false)
+    result2 = insert(:result, round: round1, ranking: 2, advancing: false)
+    result3 = insert(:result, round: round1, ranking: 3, advancing: false)
+    result4 = insert(:result, round: round1, ranking: 4, advancing: false)
 
     _round2 =
       insert(:round, competition_event: competition_event, number: 2, advancement_condition: nil)

--- a/server/test/wca_live/scoretaking/advancing_test.exs
+++ b/server/test/wca_live/scoretaking/advancing_test.exs
@@ -110,8 +110,8 @@ defmodule WcaLive.Scoretaking.AdvancingTest do
     result2 = insert(:result, round: round, ranking: 2, best: 1100)
     _result3 = insert(:result, round: round, ranking: 3, best: 1200)
     _result4 = insert(:result, round: round, ranking: 4, best: 1400)
-    _result5 = insert(:result, round: round, ranking: 5)
-    _result6 = insert(:result, round: round, ranking: 6)
+    _result5 = insert(:result, round: round, ranking: nil)
+    _result6 = insert(:result, round: round, ranking: nil)
 
     assert ids([result1, result2]) == ids(Advancing.qualifying_results(round))
   end


### PR DESCRIPTION
Dear WST, @gregorbg , @jonatanklosko ,

The scenario is the following:
100 competitors registered for 3x3 round 1. 75% advance to the next round. My scoretakers enter results, and WCA Live shows 75 competitors advance to the next round, with the green label on their ranking. However, 5 people did not show up. My scoretakers remove those 5 people. Now, only 71 competitors advance to the next round. The competitors ranked 72nd, 73th, 74th and 75th are terribly disappointed because WCA Live tricked them into believing they were going to round 2.

This has been a returning issue at hundreds of competitions worldwide and yesterday, we had the same issue with one person thinking he was going to round 2 and then we had to remove him. One of the organizers then decided to give up his spot in round 2, so the other competitor could be added to round 2 instead.

This PR attempts to fix that. However, I don't know Euphoria and I did not setup anything locally to run the tests :-) So I hope you can help me if the tests are not working, or if I did anything else wrong. Thanks in advance for your time!