### PR TITLE
Add 'level' property back to Qualification encoding

### DIFF
--- a/server/lib/wca_live/competitions/qualification.ex
+++ b/server/lib/wca_live/competitions/qualification.ex
@@ -6,7 +6,7 @@ defmodule WcaLive.Competitions.Qualification do
   use WcaLive.Schema
   import Ecto.Changeset
 
-  @required_fields [:type, :result_type, :when_date]
+  @required_fields [:type, :result_type, :when_date, :level]
   @optional_fields []
 
   @primary_key false


### PR DESCRIPTION
Was accidentally deleted in https://github.com/thewca/wca-live/pull/104

In particular, synchronizing competitions that had qualification results caused `Validation failed: Qualification is invalid` errors to pop up, because the JSON was serialized with `"level": null`.

I verified locally that this fix works by testing with `SpanishChampionship2022`. Importing, then immediately re-syncing without any changes yields the error without my fix, but works with the fix from this patch. I didn't bother setting up the test environment as this is my first PR and it's such a trivial fix, but I really wonder why the automated test suite didn't catch this?!