### PR TITLE
Replace PB with PR

### DIFF
--- a/client/src/components/RecordTag/RecordTag.js
+++ b/client/src/components/RecordTag/RecordTag.js
@@ -15,7 +15,7 @@ const styles = {
     color: (theme) => theme.palette.getContrastText(green['A400']),
     backgroundColor: green['A400'],
   },
-  pb: {
+  pr: {
     color: (theme) => theme.palette.getContrastText(blue[700]),
     backgroundColor: blue[700],
   },

--- a/client/src/components/RecordTagBadge/RecordTagBadge.js
+++ b/client/src/components/RecordTagBadge/RecordTagBadge.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { Box } from '@mui/material';
 import RecordTag from '../RecordTag/RecordTag';
 
-function RecordTagBadge({ recordTag, hidePb = false, children }) {
-  if (!recordTag || (hidePb && recordTag === 'PB')) {
+function RecordTagBadge({ recordTag, hidePr = false, children }) {
+  if (!recordTag || (hidePr && recordTag === 'PR')) {
     return children;
   }
 

--- a/client/src/components/ResultsProjector/ResultsProjector.js
+++ b/client/src/components/ResultsProjector/ResultsProjector.js
@@ -221,7 +221,7 @@ function ResultsProjector({ results, format, eventId, title, exitUrl }) {
                       >
                         <RecordTagBadge
                           recordTag={result[recordTagField]}
-                          hidePb
+                          hidePr
                         >
                           {formatAttemptResult(result[field], eventId)}
                         </RecordTagBadge>

--- a/client/src/components/RoundResults/RoundResultDialog.js
+++ b/client/src/components/RoundResults/RoundResultDialog.js
@@ -67,7 +67,7 @@ function RoundResultDialog({
                       <Typography variant="body2">
                         <RecordTagBadge
                           recordTag={result[recordTagField]}
-                          hidePb
+                          hidePr
                         >
                           {formatAttemptResult(result[field], eventId)}
                         </RecordTagBadge>

--- a/client/src/components/RoundResults/RoundResultsTable.js
+++ b/client/src/components/RoundResults/RoundResultsTable.js
@@ -129,7 +129,7 @@ const RoundResultsTable = React.memo(
                       fontWeight: index === 0 ? 600 : 400,
                     }}
                   >
-                    <RecordTagBadge recordTag={result[recordTagField]} hidePb>
+                    <RecordTagBadge recordTag={result[recordTagField]} hidePr>
                       {formatAttemptResult(result[field], eventId)}
                     </RecordTagBadge>
                   </TableCell>

--- a/client/src/components/admin/AdminRound/AdminResultsTable.js
+++ b/client/src/components/admin/AdminRound/AdminResultsTable.js
@@ -132,7 +132,7 @@ const AdminResultsTable = React.memo(
                   align="right"
                   sx={{ fontWeight: index === 0 ? 600 : 400 }}
                 >
-                  <RecordTagBadge recordTag={result[recordTagField]} hidePb>
+                  <RecordTagBadge recordTag={result[recordTagField]} hidePr>
                     {formatAttemptResult(result[field], eventId)}
                   </RecordTagBadge>
                 </TableCell>

--- a/lib/wca_live/scoretaking/record_tags.ex
+++ b/lib/wca_live/scoretaking/record_tags.ex
@@ -85,7 +85,7 @@ defmodule WcaLive.Scoretaking.RecordTags do
       %{tag: "CR", record_key: Wca.Records.record_key(event_id, type, country.continent_name)},
       %{tag: "NR", record_key: Wca.Records.record_key(event_id, type, country.iso2)},
       %{
-        tag: "PB",
+        tag: "PR",
         record_key: Wca.Records.record_key(event_id, type, person_record_scope(person))
       }
     ]

--- a/lib/wca_live/scoretaking/round.ex
+++ b/lib/wca_live/scoretaking/round.ex
@@ -88,7 +88,7 @@ defmodule WcaLive.Scoretaking.Round do
   defp regional_record_tags(results) do
     results
     |> Enum.flat_map(fn result -> [result.average_record_tag, result.single_record_tag] end)
-    |> Enum.filter(fn tag -> tag not in [nil, "PB"] end)
+    |> Enum.filter(fn tag -> tag not in [nil, "PR"] end)
     |> Enum.uniq()
   end
 

--- a/test/wca_live/scoretaking/record_tags_test.exs
+++ b/test/wca_live/scoretaking/record_tags_test.exs
@@ -35,7 +35,7 @@ defmodule WcaLive.Scoretaking.RecordTagsTest do
     changeset = RecordTags.compute_record_tags(competition_event)
 
     assert %{
-             result.id => %{single: "PB", average: "PB"}
+             result.id => %{single: "PR", average: "PR"}
            } == competition_event_changeset_to_record_tags_map(changeset)
   end
 
@@ -104,8 +104,8 @@ defmodule WcaLive.Scoretaking.RecordTagsTest do
     changeset = RecordTags.compute_record_tags(competition_event)
 
     assert %{
-             person1_result.id => %{single: "PB", average: "WR"},
-             person2_result.id => %{single: "WR", average: "PB"}
+             person1_result.id => %{single: "PR", average: "WR"},
+             person2_result.id => %{single: "WR", average: "PR"}
            } == competition_event_changeset_to_record_tags_map(changeset)
   end
 

--- a/test/wca_live/scoretaking/round_test.exs
+++ b/test/wca_live/scoretaking/round_test.exs
@@ -17,11 +17,11 @@ defmodule WcaLive.Scoretaking.RoundTest do
     assert "CR" == Round.label(round)
   end
 
-  test "label/1 ignores PB record tags" do
+  test "label/1 ignores PR record tags" do
     round =
       build(:round,
         results: [
-          build(:result, average_record_tag: "PB"),
+          build(:result, average_record_tag: "PR"),
           build(:result, attempts: []),
           build(:result, attempts: [])
         ]

--- a/test/wca_live/scoretaking_test.exs
+++ b/test/wca_live/scoretaking_test.exs
@@ -191,7 +191,7 @@ defmodule WcaLive.ScoretakingTest do
     ]
 
     assert {:ok, updated} = Scoretaking.enter_result_attempts(result, attempts_attrs, user)
-    assert "PB" == updated.single_record_tag
+    assert "PR" == updated.single_record_tag
     assert nil == updated.average_record_tag
   end
 

--- a/test/wca_live/synchronization/import_test.exs
+++ b/test/wca_live/synchronization/import_test.exs
@@ -266,7 +266,7 @@ defmodule WcaLive.Synchronization.ImportTest do
     assert 2 == length(personal_bests)
 
     single333 =
-      Enum.find(personal_bests, fn pb -> pb.event_id == "333" and pb.type == "single" end)
+      Enum.find(personal_bests, fn pr -> pr.event_id == "333" and pr.type == "single" end)
 
     assert 790 == single333.best
   end


### PR DESCRIPTION
This PR changes the RecordTag to read PR instead of PB. For the sake of internal consistency, it also replaces references of "pb" and its variations throughout the code. Addresses #121.

Preview: 
![image](https://user-images.githubusercontent.com/33607815/202865268-96d780c6-07a4-4f91-88ba-60401c46603a.png)
