### PR TITLE
Show PR badge on round results table and dialog

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Erlang & Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: '24.1.6'
+          otp-version: '24.2'
           elixir-version: '1.12.3'
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install wkhtmltopdf

--- a/client/src/components/RoundResults/RoundResultDialog.js
+++ b/client/src/components/RoundResults/RoundResultDialog.js
@@ -65,9 +65,7 @@ function RoundResultDialog({
                     <Grid item key={name}>
                       <Typography variant="subtitle2">{name}</Typography>
                       <Typography variant="body2">
-                        <RecordTagBadge
-                          recordTag={result[recordTagField]}
-                        >
+                        <RecordTagBadge recordTag={result[recordTagField]}>
                           {formatAttemptResult(result[field], eventId)}
                         </RecordTagBadge>
                       </Typography>

--- a/client/src/components/RoundResults/RoundResultDialog.js
+++ b/client/src/components/RoundResults/RoundResultDialog.js
@@ -67,7 +67,6 @@ function RoundResultDialog({
                       <Typography variant="body2">
                         <RecordTagBadge
                           recordTag={result[recordTagField]}
-                          hidePr
                         >
                           {formatAttemptResult(result[field], eventId)}
                         </RecordTagBadge>

--- a/client/src/components/RoundResults/RoundResultsTable.js
+++ b/client/src/components/RoundResults/RoundResultsTable.js
@@ -129,7 +129,7 @@ const RoundResultsTable = React.memo(
                       fontWeight: index === 0 ? 600 : 400,
                     }}
                   >
-                    <RecordTagBadge recordTag={result[recordTagField]} hidePr>
+                    <RecordTagBadge recordTag={result[recordTagField]}>
                       {formatAttemptResult(result[field], eventId)}
                     </RecordTagBadge>
                   </TableCell>


### PR DESCRIPTION
The PR badges were accidentally shown on the results table previously, but it generated a good response in the short time that the "feature" was live. There was some discussion on this at [this pull request](https://github.com/thewca/wca-live/pull/122). This commit officially changes the round results table and the round result dialog to show the PR badges when relevant. It does not change the admin results table (displayed while inserting times) nor does it change the results projector view, both of which continue to hide the PR badge.

## Previews

### Round Results Table

![image](https://user-images.githubusercontent.com/33607815/203180880-10d38b16-9632-4edc-b3c8-455ca0a85fc2.png)

### Round Result Dialog

![image](https://user-images.githubusercontent.com/33607815/203181155-71e6c938-eb12-4e63-960c-bf76a574498f.png)



