### PR TITLE
Add litePr flag and use on RoundResultsTable

### DIFF
--- a/client/src/components/RecordTag/RecordTag.js
+++ b/client/src/components/RecordTag/RecordTag.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { red, yellow, green, blue } from '@mui/material/colors';
+import { red, yellow, green, blue, grey } from '@mui/material/colors';
 
 const styles = {
   wr: {
@@ -19,9 +19,22 @@ const styles = {
     color: (theme) => theme.palette.getContrastText(blue[700]),
     backgroundColor: blue[700],
   },
+  litePr: {
+    color: (theme) =>
+      theme.palette.getContrastText(
+        theme.palette.mode === 'dark' ? grey[800] : grey[200]
+      ),
+    backgroundColor: (theme) =>
+      theme.palette.mode === 'dark' ? grey[800] : grey[200],
+  },
 };
 
-function RecordTag({ recordTag, sx }) {
+function RecordTag({ recordTag, sx, litePr = false }) {
+  const tagStyle =
+    litePr && recordTag === 'PR'
+      ? styles.litePr
+      : styles[recordTag.toLowerCase()] || {};
+
   return (
     <Box
       component="span"
@@ -34,7 +47,7 @@ function RecordTag({ recordTag, sx }) {
         fontWeight: 600,
         fontSize: '0.7em',
         ...sx,
-        ...(styles[recordTag.toLowerCase()] || {}),
+        ...tagStyle,
       }}
     >
       {recordTag}

--- a/client/src/components/RecordTagBadge/RecordTagBadge.js
+++ b/client/src/components/RecordTagBadge/RecordTagBadge.js
@@ -2,7 +2,12 @@ import React from 'react';
 import { Box } from '@mui/material';
 import RecordTag from '../RecordTag/RecordTag';
 
-function RecordTagBadge({ recordTag, hidePr = false, children }) {
+function RecordTagBadge({
+  recordTag,
+  hidePr = false,
+  litePr = false,
+  children,
+}) {
   if (!recordTag || (hidePr && recordTag === 'PR')) {
     return children;
   }
@@ -12,6 +17,7 @@ function RecordTagBadge({ recordTag, hidePr = false, children }) {
       {children}
       <RecordTag
         recordTag={recordTag}
+        litePr={litePr}
         sx={{
           position: 'absolute',
           top: 0,

--- a/client/src/components/RoundResults/RoundResultsTable.js
+++ b/client/src/components/RoundResults/RoundResultsTable.js
@@ -129,7 +129,7 @@ const RoundResultsTable = React.memo(
                       fontWeight: index === 0 ? 600 : 400,
                     }}
                   >
-                    <RecordTagBadge recordTag={result[recordTagField]}>
+                    <RecordTagBadge litePr recordTag={result[recordTagField]}>
                       {formatAttemptResult(result[field], eventId)}
                     </RecordTagBadge>
                   </TableCell>


### PR DESCRIPTION
When many PRs were broken, the blue PR badges would cover the round results table. This commit adds an alternative style called `litePr` which has a background that matches the current color scheme: light on light mode and dark on dark mode. This new style is used on the round results table, so that the PRs still appear on the round results table in a less distracting appearance. Otherwise, the standard blue badges are used for PR in all other contexts. Addressing #126.

There's a little bit of repeated code in the new styling but making it not repeat would be about the same amount of code. There's also a little bit of prop drilling from `RoundResultsTable` through `RecordTagBadge` to the final `RecordTag`. Please advise if there's a better approach (I have literally never had my React code reviewed by someone else before) :)

Round Results Table:

![image](https://user-images.githubusercontent.com/33607815/204184248-370696e4-8bc9-43ef-a33e-02b3a6c1be63.png)
![image](https://user-images.githubusercontent.com/33607815/204184325-02c18ed2-c797-4edd-b3a5-61ad4445c799.png)

Competitor Result Dialog (unchanged):

![image](https://user-images.githubusercontent.com/33607815/204184208-08107dec-68fd-4c07-ae1a-fc3ef1469b3f.png)

Competitor Results (unchanged):

![image](https://user-images.githubusercontent.com/33607815/204184390-1e9eca39-91ab-4916-a344-67e0583b2b7a.png)

