### PR TITLE
Add bulk quit for no-show competitors

### DIFF
--- a/client/src/components/admin/AdminCompetitionNavigation/AdminCompetitionNavigation.js
+++ b/client/src/components/admin/AdminCompetitionNavigation/AdminCompetitionNavigation.js
@@ -48,7 +48,7 @@ function AdminCompetitionNavigation() {
           <Route path="settings" element={<AdminSettings />} />
         )}
         <Route
-          path="rounds/:roundId/doublecheck"
+          path="rounds/:roundId/double-check"
           element={<RoundDoubleCheck />}
         />
         <Route path="rounds/:roundId" element={<AdminRound />} />

--- a/client/src/components/admin/AdminRound/AdminRoundContent.js
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.js
@@ -18,6 +18,7 @@ const ENTER_RESULT_ATTEMPTS = gql`
         id
         round {
           id
+          number
           results {
             id
             ...adminRoundResult
@@ -85,7 +86,7 @@ function AdminRoundContent({ round, competitionId }) {
 
       return () => closeSnackbar(snackbarId);
     }
-  }, [nextOpen, enqueueSnackbar]);
+  }, [nextOpen, enqueueSnackbar, closeSnackbar]);
 
   return (
     <>

--- a/client/src/components/admin/AdminRound/AdminRoundToolbar.js
+++ b/client/src/components/admin/AdminRound/AdminRoundToolbar.js
@@ -3,8 +3,10 @@ import { Link as RouterLink } from 'react-router-dom';
 import { Grid, IconButton, Tooltip, Typography } from '@mui/material';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import CheckIcon from '@mui/icons-material/Check';
+import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
 import PrintIcon from '@mui/icons-material/Print';
 import AddCompetitorDialog from './AddCompetitorDialog';
+import QuitNoShowsDialog from './QuitNoShowsDialog';
 import { appUrl } from '../../../lib/urls';
 
 function roundDescription(round) {
@@ -16,6 +18,7 @@ function roundDescription(round) {
 
 function AdminRoundToolbar({ round, competitionId }) {
   const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [quitNoShowsOpen, setQuitNoShowsOpen] = useState(false);
 
   return (
     <>
@@ -48,17 +51,33 @@ function AdminRoundToolbar({ round, competitionId }) {
           <Tooltip title="Double-check" placement="top">
             <IconButton
               component={RouterLink}
-              to={`/admin/competitions/${competitionId}/rounds/${round.id}/doublecheck`}
+              to={`/admin/competitions/${competitionId}/rounds/${round.id}/double-check`}
               size="large"
             >
               <CheckIcon />
             </IconButton>
           </Tooltip>
+          {/* For subsequent rounds there are few no-shows and they may
+              be replaced with competitors from the previous round, so
+              we enable the bulk quit only for the first round */}
+          {round.number === 1 && (
+            <Tooltip title="Bulk quit no-shows" placement="top">
+              <IconButton onClick={() => setQuitNoShowsOpen(true)} size="large">
+                <DeleteSweepIcon />
+              </IconButton>
+            </Tooltip>
+          )}
         </Grid>
       </Grid>
       <AddCompetitorDialog
         open={addDialogOpen}
         onClose={() => setAddDialogOpen(false)}
+        roundId={round.id}
+      />
+      <QuitNoShowsDialog
+        open={quitNoShowsOpen}
+        onClose={() => setQuitNoShowsOpen(false)}
+        results={round.results}
         roundId={round.id}
       />
     </>

--- a/client/src/components/admin/AdminRound/QuitNoShowsDialog.js
+++ b/client/src/components/admin/AdminRound/QuitNoShowsDialog.js
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { gql, useMutation } from '@apollo/client';
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Grid,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { ADMIN_ROUND_RESULT_FRAGMENT } from './fragments';
+import useApolloErrorHandler from '../../../hooks/useApolloErrorHandler';
+import { orderBy, toggleElement } from '../../../lib/utils';
+
+const REMOVE_NO_SHOWS_FROM_ROUND_MUTATION = gql`
+  mutation RemoveNoShowsFromRound($input: RemoveNoShowsFromRoundInput!) {
+    removeNoShowsFromRound(input: $input) {
+      round {
+        id
+        results {
+          id
+          ...adminRoundResult
+        }
+      }
+    }
+  }
+  ${ADMIN_ROUND_RESULT_FRAGMENT}
+`;
+
+function QuitNoShowsDialog({ open, onClose, roundId, results }) {
+  const apolloErrorHandler = useApolloErrorHandler();
+
+  const [selectedPersonIds, setSelectedPersonIds] = useState([]);
+
+  const [removeNoShowsFromRound, { loading: mutationLoading }] = useMutation(
+    REMOVE_NO_SHOWS_FROM_ROUND_MUTATION,
+    {
+      variables: {
+        input: {
+          roundId,
+          personIds: selectedPersonIds,
+        },
+      },
+      onCompleted: handleClose,
+      onError: apolloErrorHandler,
+    }
+  );
+
+  const noShowResults = orderBy(
+    results.filter((result) => result.attempts.length === 0),
+    (result) => result.person.name
+  );
+
+  function onResultClick(result) {
+    setSelectedPersonIds(toggleElement(selectedPersonIds, result.person.id));
+  }
+
+  function handleClose() {
+    setSelectedPersonIds([]);
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Quit no-shows</DialogTitle>
+      <DialogContent>
+        {noShowResults.length > 0 ? (
+          <Grid container direction="column" spacing={2}>
+            <Grid item>
+              <DialogContentText>
+                Here you can quickly select and quit competitors that did not
+                show up.
+              </DialogContentText>
+            </Grid>
+            <Grid item>
+              <List
+                dense
+                sx={{
+                  overflowY: 'auto',
+                  maxHeight: 600,
+                }}
+              >
+                {noShowResults.map((result) => (
+                  <ListItem key={result.id}>
+                    <ListItemButton dense onClick={() => onResultClick(result)}>
+                      <ListItemIcon>
+                        <Checkbox
+                          edge="start"
+                          checked={selectedPersonIds.includes(result.person.id)}
+                          tabIndex={-1}
+                          disableRipple
+                        />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={`${result.person.name} (${result.person.registrantId})`}
+                      />
+                    </ListItemButton>
+                  </ListItem>
+                ))}
+              </List>
+              <Typography variant="caption">
+                {selectedPersonIds.length} of {noShowResults.length} selected
+              </Typography>
+            </Grid>
+          </Grid>
+        ) : (
+          <DialogContentText>{`All results are entered.`}</DialogContentText>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          onClick={() => removeNoShowsFromRound()}
+          color="primary"
+          disabled={selectedPersonIds.length === 0 || mutationLoading}
+        >
+          Quit
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default QuitNoShowsDialog;

--- a/client/src/lib/utils.js
+++ b/client/src/lib/utils.js
@@ -70,6 +70,10 @@ export function minBy(arr, fn) {
   return arr.reduce((x, y) => (fn(x) < fn(y) ? x : y));
 }
 
+export function toggleElement(arr, x) {
+  return arr.includes(x) ? arr.filter((y) => y !== x) : [x, ...arr];
+}
+
 export function clamp(x, left, right) {
   return Math.min(Math.max(x, left), right);
 }

--- a/lib/wca_live/scoretaking.ex
+++ b/lib/wca_live/scoretaking.ex
@@ -313,6 +313,22 @@ defmodule WcaLive.Scoretaking do
     end
   end
 
+  @doc """
+  Removes results from `round` corresponding to the given `person_ids`,
+  provided they have no attempts.
+  """
+  @spec remove_no_shows_from_round(%Round{}, list(pos_integer())) ::
+          {:ok, %Round{}} | {:error, String.t() | Ecto.Changeset.t()}
+  def remove_no_shows_from_round(round, person_ids) do
+    round = round |> Repo.preload(:results)
+
+    results = Enum.reject(round.results, &(&1.person_id in person_ids and &1.attempts == []))
+
+    results
+    |> Round.put_results_in_round(round)
+    |> update_round_and_advancing()
+  end
+
   # Saves the given round changeset and recomputes `advancing` for
   # results in this and the previous round.
 

--- a/lib/wca_live_web/resolvers/scoretaking_mutation.ex
+++ b/lib/wca_live_web/resolvers/scoretaking_mutation.ex
@@ -50,6 +50,20 @@ defmodule WcaLiveWeb.Resolvers.ScoretakingMutation do
 
   def remove_person_from_round(_parent, _args, _resolution), do: @not_authenticated
 
+  def remove_no_shows_from_round(_parent, %{input: input}, %{
+        context: %{current_user: current_user}
+      }) do
+    person_ids = Enum.map(input.person_ids, &String.to_integer/1)
+
+    with {:ok, round} <- Scoretaking.fetch_round(input.round_id),
+         true <- Scoretaking.Access.can_manage_round?(current_user, round) || @access_denied,
+         {:ok, round} <- Scoretaking.remove_no_shows_from_round(round, person_ids) do
+      {:ok, %{round: round}}
+    end
+  end
+
+  def remove_no_shows_from_round(_parent, _args, _resolution), do: @not_authenticated
+
   # Results
 
   def enter_result_attempts(_parent, %{input: input}, %{context: %{current_user: current_user}}) do

--- a/lib/wca_live_web/schema/scoretaking_mutation_types.ex
+++ b/lib/wca_live_web/schema/scoretaking_mutation_types.ex
@@ -28,6 +28,11 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypes do
       arg :input, non_null(:remove_person_from_round_input)
       resolve &Resolvers.ScoretakingMutation.remove_person_from_round/3
     end
+
+    field :remove_no_shows_from_round, non_null(:remove_no_shows_from_round_payload) do
+      arg :input, non_null(:remove_no_shows_from_round_input)
+      resolve &Resolvers.ScoretakingMutation.remove_no_shows_from_round/3
+    end
   end
 
   # Inputs
@@ -61,6 +66,11 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypes do
     field :replace, non_null(:boolean)
   end
 
+  input_object :remove_no_shows_from_round_input do
+    field :round_id, non_null(:id)
+    field :person_ids, non_null(list_of(non_null(:id)))
+  end
+
   # Payloads
 
   object :open_round_payload do
@@ -80,6 +90,10 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypes do
   end
 
   object :remove_person_from_round_payload do
+    field :round, :round
+  end
+
+  object :remove_no_shows_from_round_payload do
     field :round, :round
   end
 end

--- a/lib/wca_live_web/schema/scoretaking_subscription_types.ex
+++ b/lib/wca_live_web/schema/scoretaking_subscription_types.ex
@@ -27,6 +27,11 @@ defmodule WcaLiveWeb.Schema.ScoretakingSubscriptionTypes do
           %{round: round} -> round && round.id
         end
 
+      trigger :remove_no_shows_from_round,
+        topic: fn
+          %{round: round} -> round && round.id
+        end
+
       resolve fn
         %{round: round}, _, _ ->
           {:ok, round}

--- a/test/wca_live_web/schema/scoretaking_types_test.exs
+++ b/test/wca_live_web/schema/scoretaking_types_test.exs
@@ -132,7 +132,11 @@ defmodule WcaLiveWeb.Schema.ScoretakingTypesTest do
         insert(:result, round: round, ranking: 4, person: build(:person, name: "Ron Weasley"))
 
       result3 =
-        insert(:result, round: round, ranking: 2, person: build(:person, name: "Hermione Granger"))
+        insert(:result,
+          round: round,
+          ranking: 2,
+          person: build(:person, name: "Hermione Granger")
+        )
 
       result2 =
         insert(:result, round: round, ranking: 2, person: build(:person, name: "Harry Potter"))


### PR DESCRIPTION
Closes #96.

Allows for bulk-quitting competitors in first rounds:

<img width="1512" alt="image" src="https://github.com/thewca/wca-live/assets/17034772/737b4bf9-493e-4fc8-841d-5162bb7f35b2">