### PR TITLE
Add newcomer indicator to admin results table

### DIFF
--- a/client/src/components/admin/AdminRound/AdminResultsTable.js
+++ b/client/src/components/admin/AdminRound/AdminResultsTable.js
@@ -6,7 +6,9 @@ import {
   TableHead,
   TableRow,
   TableSortLabel,
+  Tooltip,
 } from '@mui/material';
+import EmojiPeopleIcon from '@mui/icons-material/EmojiPeople';
 import { green } from '@mui/material/colors';
 import { times } from '../../../lib/utils';
 import { formatAttemptResult } from '../../../lib/attempt-result';
@@ -118,7 +120,18 @@ const AdminResultsTable = React.memo(
                 {result.ranking}
               </TableCell>
               <TableCell align="right">{result.person.registrantId}</TableCell>
-              <TableCell>{result.person.name}</TableCell>
+              <TableCell>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                  <div>{result.person.name}</div>
+                  {!result.person.wcaId && (
+                    <div style={{ display: 'flex' }}>
+                      <Tooltip title="Newcomer" placement="right">
+                        <EmojiPeopleIcon fontSize="small" />
+                      </Tooltip>
+                    </div>
+                  )}
+                </div>
+              </TableCell>
               {paddedAttemptResults(result, format.numberOfAttempts).map(
                 (attemptResult, index) => (
                   <TableCell key={index} align="right">

--- a/client/src/components/admin/AdminRound/fragments.js
+++ b/client/src/components/admin/AdminRound/fragments.js
@@ -15,6 +15,7 @@ export const ADMIN_ROUND_RESULT_FRAGMENT = gql`
       id
       registrantId
       name
+      wcaId
     }
     singleRecordTag
     averageRecordTag


### PR DESCRIPTION
Closes #146.

<img width="1029" alt="image" src="https://github.com/thewca/wca-live/assets/17034772/642e3805-e3ff-47d3-9a5a-4b821fadcd98">