### PR TITLE
Add WCIF export endpoint

### DIFF
--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -1,0 +1,28 @@
+defmodule WcaLiveWeb.CompetitionController do
+  use WcaLiveWeb, :controller
+
+  alias WcaLive.Competitions
+
+  def show_wcif(conn, params) do
+    case Competitions.fetch_competition(params["id"]) do
+      {:ok, competition} ->
+        if conn.assigns.current_user &&
+             Competitions.Access.can_manage_competition?(conn.assigns.current_user, competition) do
+          wcif = WcaLive.Synchronization.Export.export_competition(competition)
+
+          conn
+          |> put_status(200)
+          |> json(wcif)
+        else
+          conn
+          |> put_status(403)
+          |> json(%{error: "access denied"})
+        end
+
+      {:error, _} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "not found"})
+    end
+  end
+end

--- a/lib/wca_live_web/router.ex
+++ b/lib/wca_live_web/router.ex
@@ -43,6 +43,12 @@ defmodule WcaLiveWeb.Router do
     get "/competitions/:wca_id/rounds/:event_id/:round_number", LinkController, :round
   end
 
+  scope "/api", WcaLiveWeb do
+    pipe_through :api
+
+    get "/competitions/:id/wcif", CompetitionController, :show_wcif
+  end
+
   scope "/api" do
     pipe_through :api
     pipe_through :graphql

--- a/test/wca_live_web/controllers/competition_controller_test.exs
+++ b/test/wca_live_web/controllers/competition_controller_test.exs
@@ -1,0 +1,37 @@
+defmodule WcaLiveWeb.CompetitionControllerTest do
+  use WcaLiveWeb.ConnCase
+
+  import WcaLive.Factory
+
+  describe "show_wcif" do
+    @tag :signed_in
+    test "returns WCIF when authorized", %{conn: conn, current_user: current_user} do
+      competition = insert(:competition, wca_id: "WC2019")
+      insert(:staff_member, competition: competition, user: current_user, roles: ["delegate"])
+
+      conn = get(conn, "/api/competitions/#{competition.id}/wcif")
+
+      body = json_response(conn, 200)
+      assert %{"formatVersion" => "1.0", "id" => "WC2019"} = body
+    end
+
+    test "returns error when not signed in", %{conn: conn} do
+      competition = insert(:competition, wca_id: "WC2019")
+
+      conn = get(conn, "/api/competitions/#{competition.id}/wcif")
+
+      body = json_response(conn, 403)
+      assert body == %{"error" => "access denied"}
+    end
+
+    @tag :signed_in
+    test "returns error when not authorized", %{conn: conn} do
+      competition = insert(:competition, wca_id: "WC2019")
+
+      conn = get(conn, "/api/competitions/#{competition.id}/wcif")
+
+      body = json_response(conn, 403)
+      assert body == %{"error" => "access denied"}
+    end
+  end
+end


### PR DESCRIPTION
Allows for exporting WCIF directly from WCA Live under `/api/competitions/:id/wcif` just in case.