### PR TITLE
Add support for batch result entry

### DIFF
--- a/client/src/components/admin/AdminRound/AdminRoundContent.js
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.js
@@ -1,6 +1,15 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { gql, useMutation } from '@apollo/client';
-import { Grid, Paper, TableContainer } from '@mui/material';
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Grid,
+  Paper,
+  TableContainer,
+  Typography,
+} from '@mui/material';
 import { useConfirm } from 'material-ui-confirm';
 import { useSnackbar } from 'notistack';
 import ResultAttemptsForm from '../ResultAttemptsForm/ResultAttemptsForm';
@@ -11,18 +20,15 @@ import { ADMIN_ROUND_RESULT_FRAGMENT } from './fragments';
 import useApolloErrorHandler from '../../../hooks/useApolloErrorHandler';
 import QuitCompetitorDialog from './QuitCompetitorDialog';
 
-const ENTER_RESULT_ATTEMPTS = gql`
-  mutation EnterResultAttempts($input: EnterResultAttemptsInput!) {
-    enterResultAttempts(input: $input) {
-      result {
+const ENTER_RESULTS = gql`
+  mutation EnterResults($input: EnterResultsInput!) {
+    enterResults(input: $input) {
+      round {
         id
-        round {
+        number
+        results {
           id
-          number
-          results {
-            id
-            ...adminRoundResult
-          }
+          ...adminRoundResult
         }
       }
     }
@@ -39,19 +45,43 @@ function AdminRoundContent({ round, competitionId }) {
   const [resultMenuProps, updateResultMenuProps] = useState({});
   const [competitorToQuit, setCompetitorToQuit] = useState(null);
 
-  const [enterResultAttempts, { loading }] = useMutation(
-    ENTER_RESULT_ATTEMPTS,
-    {
-      onCompleted: () => {
-        setEditedResult(null);
-      },
-      onError: apolloErrorHandler,
-    }
-  );
+  const [isBatchMode, setIsBatchMode] = useState(false);
+  const [batchResults, setBatchResults] = useState([]);
+  const formContainerRef = useRef(null);
+
+  const [enterResults, { loading }] = useMutation(ENTER_RESULTS, {
+    onCompleted: () => {
+      setEditedResult(null);
+
+      if (batchResults.length > 0) {
+        setBatchResults([]);
+        formContainerRef.current.querySelector('input').focus();
+      }
+    },
+    onError: apolloErrorHandler,
+  });
 
   function handleResultAttemptsSubmit(attempts) {
-    enterResultAttempts({
-      variables: { input: { id: editedResult.id, attempts } },
+    if (isBatchMode) {
+      setBatchResults([
+        ...batchResults.filter((result) => result.id !== editedResult.id),
+        { id: editedResult.id, attempts },
+      ]);
+      setEditedResult(null);
+    } else {
+      enterResults({
+        variables: {
+          input: { id: round.id, results: [{ id: editedResult.id, attempts }] },
+        },
+      });
+    }
+  }
+
+  function handleResultsBatchSubmit() {
+    enterResults({
+      variables: {
+        input: { id: round.id, results: batchResults },
+      },
     });
   }
 
@@ -59,8 +89,10 @@ function AdminRoundContent({ round, competitionId }) {
     confirm({
       description: `This will clear all attempts of ${result.person.name}.`,
     }).then(() => {
-      enterResultAttempts({
-        variables: { input: { id: result.id, attempts: [] } },
+      enterResults({
+        variables: {
+          input: { id: round.id, results: [{ id: result.id, attempts: [] }] },
+        },
       });
     });
   }
@@ -91,7 +123,7 @@ function AdminRoundContent({ round, competitionId }) {
   return (
     <>
       <Grid container direction="row" spacing={2}>
-        <Grid item xs={12} md={3}>
+        <Grid item xs={12} md={3} ref={formContainerRef}>
           <ResultAttemptsForm
             result={editedResult}
             results={round.results}
@@ -104,6 +136,40 @@ function AdminRoundContent({ round, competitionId }) {
             disabled={loading}
             onSubmit={handleResultAttemptsSubmit}
           />
+          <Box sx={{ mt: 4 }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={isBatchMode}
+                  onChange={(event) => setIsBatchMode(event.target.checked)}
+                  disabled={batchResults.length > 0}
+                />
+              }
+              label="Batch mode"
+            />
+            {isBatchMode && (
+              <Grid container direction="row" alignItems="center">
+                <Grid item>
+                  <Typography>
+                    Results in batch: {batchResults.length}
+                  </Typography>
+                </Grid>
+                <Grid item flexGrow={1}></Grid>
+                <Grid item>
+                  <Button
+                    type="submit"
+                    variant="outlined"
+                    color="primary"
+                    size="small"
+                    disabled={batchResults.length === 0 || loading}
+                    onClick={handleResultsBatchSubmit}
+                  >
+                    Submit batch
+                  </Button>
+                </Grid>
+              </Grid>
+            )}
+          </Box>
         </Grid>
         <Grid item xs={12} md={9} container direction="column" spacing={1}>
           <Grid item>

--- a/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.js
+++ b/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.js
@@ -52,12 +52,15 @@ const ROUND_QUERY = gql`
 `;
 
 const ENTER_RESULT_ATTEMPTS = gql`
-  mutation EnterResultAttempts($input: EnterResultAttemptsInput!) {
-    enterResultAttempts(input: $input) {
-      result {
+  mutation EnterResults($input: EnterResultsInput!) {
+    enterResults(input: $input) {
+      round {
         id
-        attempts {
-          result
+        results {
+          id
+          attempts {
+            result
+          }
         }
       }
     }
@@ -88,7 +91,7 @@ function RoundDoubleCheck() {
     variables: { id: roundId },
   });
 
-  const [enterResultAttempts, { error: enterLoading }] = useMutation(
+  const [enterResults, { error: enterLoading }] = useMutation(
     ENTER_RESULT_ATTEMPTS,
     {
       onCompleted: () => {
@@ -115,8 +118,13 @@ function RoundDoubleCheck() {
   }
 
   function handleResultAttemptsSubmit(attempts) {
-    enterResultAttempts({
-      variables: { input: { id: results[resultIndex].id, attempts } },
+    enterResults({
+      variables: {
+        input: {
+          id: round.id,
+          results: [{ id: results[resultIndex].id, attempts }],
+        },
+      },
     });
   }
 

--- a/lib/wca_live/scoretaking.ex
+++ b/lib/wca_live/scoretaking.ex
@@ -94,33 +94,43 @@ defmodule WcaLive.Scoretaking do
   def fetch_result(id), do: Repo.fetch(Result, id)
 
   @doc """
-  Updates result attempts with the given list.
+  Updates attempts for a batch of results.
 
-  Stores the timestamp and user who entered the attempts.
-  Also updates ranking, records and advancing based on the new state.
+  Stores the timestamp and user who entered the attempts. Also updates
+  ranking, records and advancing based on the new state.
   """
-  @spec enter_result_attempts(%Result{}, list(map()), %User{}) ::
-          {:ok, %Result{}} | {:error, Ecto.Changeset.t()}
-  def enter_result_attempts(result, attempts, user) do
-    result = Repo.preload(result, round: [:competition_event])
+  @spec enter_results(%Result{}, list({term(), list(map())}), %User{}) ::
+          {:ok, %Round{}} | {:error, Ecto.Changeset.t()}
+  def enter_results(round, result_ids_with_attempts, user) do
+    round = Repo.preload(round, [:competition_event, :results])
 
-    Multi.new()
-    |> Multi.update(:updated_result, fn _changes ->
-      format = Format.get_by_id!(result.round.format_id)
-      event_id = result.round.competition_event.event_id
-      cutoff = result.round.cutoff
+    format = Format.get_by_id!(round.format_id)
+    event_id = round.competition_event.event_id
+    cutoff = round.cutoff
 
-      result
-      |> Result.changeset(%{attempts: attempts}, event_id, format, cutoff)
-      |> Changeset.put_change(:entered_by_id, user.id)
-      |> Changeset.put_change(:entered_at, DateTime.utc_now() |> DateTime.truncate(:second))
-    end)
-    |> Multi.merge(fn %{updated_result: result} ->
-      process_round_after_results_change(result.round)
+    results_with_attempts =
+      for {result_id, attempts} <- result_ids_with_attempts,
+          result = Enum.find(round.results, &(&1.id == result_id)),
+          do: {result, attempts}
+
+    results_multi =
+      Enum.reduce(results_with_attempts, Multi.new(), fn {result, attempts}, multi ->
+        Multi.update(multi, {:updated_result, result.id}, fn _changes ->
+          result
+          |> Result.changeset(%{attempts: attempts}, event_id, format, cutoff)
+          |> Changeset.put_change(:entered_by_id, user.id)
+          |> Changeset.put_change(:entered_at, DateTime.utc_now() |> DateTime.truncate(:second))
+        end)
+      end)
+
+    results_multi
+    |> Multi.merge(fn _ ->
+      round = Repo.preload(round, :results, force: true)
+      process_round_after_results_change(round)
     end)
     |> Repo.transaction()
     |> case do
-      {:ok, _} -> {:ok, get_result!(result.id)}
+      {:ok, _} -> {:ok, get_round!(round.id)}
       {:error, _, reason, _} -> {:error, reason}
     end
   end

--- a/lib/wca_live_web/resolvers/scoretaking_mutation.ex
+++ b/lib/wca_live_web/resolvers/scoretaking_mutation.ex
@@ -66,14 +66,15 @@ defmodule WcaLiveWeb.Resolvers.ScoretakingMutation do
 
   # Results
 
-  def enter_result_attempts(_parent, %{input: input}, %{context: %{current_user: current_user}}) do
-    with {:ok, result} <- Scoretaking.fetch_result(input.id),
-         true <- Scoretaking.Access.can_manage_result?(current_user, result) || @access_denied,
-         {:ok, result} <-
-           Scoretaking.enter_result_attempts(result, input.attempts, current_user) do
-      {:ok, %{result: result}}
+  def enter_results(_parent, %{input: input}, %{context: %{current_user: current_user}}) do
+    result_inputs = for input <- input.results, do: {String.to_integer(input.id), input.attempts}
+
+    with {:ok, round} <- Scoretaking.fetch_round(input.id),
+         true <- Scoretaking.Access.can_manage_round?(current_user, round) || @access_denied,
+         {:ok, round} <- Scoretaking.enter_results(round, result_inputs, current_user) do
+      {:ok, %{round: round}}
     end
   end
 
-  def enter_result_attempts(_parent, _args, _resolution), do: @not_authenticated
+  def enter_results(_parent, _args, _resolution), do: @not_authenticated
 end

--- a/lib/wca_live_web/schema/scoretaking_mutation_types.ex
+++ b/lib/wca_live_web/schema/scoretaking_mutation_types.ex
@@ -14,9 +14,9 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypes do
       resolve &Resolvers.ScoretakingMutation.clear_round/3
     end
 
-    field :enter_result_attempts, non_null(:enter_result_attempts_payload) do
-      arg :input, non_null(:enter_result_attempts_input)
-      resolve &Resolvers.ScoretakingMutation.enter_result_attempts/3
+    field :enter_results, non_null(:enter_results_payload) do
+      arg :input, non_null(:enter_results_input)
+      resolve &Resolvers.ScoretakingMutation.enter_results/3
     end
 
     field :add_person_to_round, non_null(:add_person_to_round_payload) do
@@ -46,6 +46,16 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypes do
   end
 
   input_object :enter_result_attempts_input do
+    field :id, non_null(:id)
+    field :attempts, non_null(list_of(non_null(:attempt_input)))
+  end
+
+  input_object :enter_results_input do
+    field :id, non_null(:id)
+    field :results, non_null(list_of(non_null(:result_attempts_input)))
+  end
+
+  input_object :result_attempts_input do
     field :id, non_null(:id)
     field :attempts, non_null(list_of(non_null(:attempt_input)))
   end
@@ -81,8 +91,9 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypes do
     field :round, :round
   end
 
-  object :enter_result_attempts_payload do
-    field :result, :result
+  object :enter_results_payload do
+    field :round, :round
+    field :results, list_of(:result)
   end
 
   object :add_person_to_round_payload do

--- a/lib/wca_live_web/schema/scoretaking_subscription_types.ex
+++ b/lib/wca_live_web/schema/scoretaking_subscription_types.ex
@@ -12,9 +12,9 @@ defmodule WcaLiveWeb.Schema.ScoretakingSubscriptionTypes do
         {:ok, topic: args.id, context_id: "global"}
       end
 
-      trigger :enter_result_attempts,
+      trigger :enter_results,
         topic: fn
-          %{result: result} -> result && result.round_id
+          %{round: round} -> round && round.id
         end
 
       trigger :add_person_to_round,

--- a/test/wca_live_web/schema/scoretaking_mutation_types_test.exs
+++ b/test/wca_live_web/schema/scoretaking_mutation_types_test.exs
@@ -173,16 +173,18 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypesTest do
 
   describe "mutation: enter result attempts" do
     @enter_reslut_attempt_mutation """
-    mutation EnterResultAttempts($input: EnterResultAttemptInput!) {
-      enterResultAttempts(input: $input) {
-        result {
-          id
-          attempts {
-            result
+    mutation EnterResults($input: EnterResultsInput!) {
+      enterResults(input: $input) {
+        round {
+          results {
+            id
+            attempts {
+              result
+            }
+            best
+            average
+            ranking
           }
-          best
-          average
-          ranking
         }
       }
     }
@@ -194,13 +196,18 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypesTest do
       result = insert(:result, round: round)
 
       input = %{
-        "id" => to_gql_id(result.id),
-        "attempts" => [
-          %{"result" => 1500},
-          %{"result" => 1400},
-          %{"result" => 1300},
-          %{"result" => -1},
-          %{"result" => 1100}
+        "id" => to_gql_id(round.id),
+        "results" => [
+          %{
+            "id" => to_gql_id(result.id),
+            "attempts" => [
+              %{"result" => 1500},
+              %{"result" => 1400},
+              %{"result" => 1300},
+              %{"result" => -1},
+              %{"result" => 1100}
+            ]
+          }
         ]
       }
 
@@ -214,19 +221,23 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypesTest do
 
       assert %{
                "data" => %{
-                 "enterResultAttempts" => %{
-                   "result" => %{
-                     "id" => to_gql_id(result.id),
-                     "attempts" => [
-                       %{"result" => 1500},
-                       %{"result" => 1400},
-                       %{"result" => 1300},
-                       %{"result" => -1},
-                       %{"result" => 1100}
-                     ],
-                     "best" => 1100,
-                     "average" => 1400,
-                     "ranking" => 1
+                 "enterResults" => %{
+                   "round" => %{
+                     "results" => [
+                       %{
+                         "id" => to_gql_id(result.id),
+                         "attempts" => [
+                           %{"result" => 1500},
+                           %{"result" => 1400},
+                           %{"result" => 1300},
+                           %{"result" => -1},
+                           %{"result" => 1100}
+                         ],
+                         "best" => 1100,
+                         "average" => 1400,
+                         "ranking" => 1
+                       }
+                     ]
                    }
                  }
                }
@@ -239,8 +250,13 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypesTest do
       result = insert(:result, round: round)
 
       input = %{
-        "id" => to_gql_id(result.id),
-        "attempts" => []
+        "id" => to_gql_id(round.id),
+        "results" => [
+          %{
+            "id" => to_gql_id(result.id),
+            "attempts" => []
+          }
+        ]
       }
 
       conn =
@@ -251,7 +267,7 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypesTest do
 
       body = json_response(conn, 200)
 
-      assert %{"data" => %{"enterResultAttempts" => _}} = body
+      assert %{"data" => %{"enterResults" => _}} = body
       assert false == Map.has_key?(body, "errors")
     end
 
@@ -261,8 +277,13 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypesTest do
       result = insert(:result, round: round)
 
       input = %{
-        "id" => to_gql_id(result.id),
-        "attempts" => []
+        "id" => to_gql_id(round.id),
+        "results" => [
+          %{
+            "id" => to_gql_id(result.id),
+            "attempts" => []
+          }
+        ]
       }
 
       conn =


### PR DESCRIPTION
Closes #47.

Scoretakers can opt-in for a batch mode, in which results are accumulated until they hit "Submit batch".

![image](https://github.com/thewca/wca-live/assets/17034772/8c73da65-f0dc-4a30-abb7-995b13620254)