### PR TITLE
Add warning when submitting new world record

### DIFF
--- a/client/src/components/admin/AdminRound/AdminRound.js
+++ b/client/src/components/admin/AdminRound/AdminRound.js
@@ -42,6 +42,13 @@ const ROUND_QUERY = gql`
         ...adminRoundResult
       }
     }
+    officialWorldRecords {
+      event {
+        id
+      }
+      type
+      attemptResult
+    }
   }
   ${ADMIN_ROUND_RESULT_FRAGMENT}
 `;
@@ -55,9 +62,15 @@ function AdminRound() {
 
   if (loading && !data) return <Loading />;
   if (error) return <Error error={error} />;
-  const { round } = data;
+  const { round, officialWorldRecords } = data;
 
-  return <AdminRoundContent round={round} competitionId={competitionId} />;
+  return (
+    <AdminRoundContent
+      round={round}
+      competitionId={competitionId}
+      officialWorldRecords={officialWorldRecords}
+    />
+  );
 }
 
 export default AdminRound;

--- a/client/src/components/admin/AdminRound/AdminRoundContent.js
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.js
@@ -36,7 +36,7 @@ const ENTER_RESULTS = gql`
   ${ADMIN_ROUND_RESULT_FRAGMENT}
 `;
 
-function AdminRoundContent({ round, competitionId }) {
+function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
   const confirm = useConfirm();
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const apolloErrorHandler = useApolloErrorHandler();
@@ -135,6 +135,7 @@ function AdminRoundContent({ round, competitionId }) {
             focusOnResultChange={true}
             disabled={loading}
             onSubmit={handleResultAttemptsSubmit}
+            officialWorldRecords={officialWorldRecords}
           />
           <Box sx={{ mt: 4 }}>
             <FormControlLabel

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.js
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.js
@@ -33,6 +33,7 @@ function ResultAttemptsForm({
   onSubmit,
   disabled = false,
   focusOnResultChange = false,
+  officialWorldRecords,
 }) {
   const confirm = useConfirm();
 
@@ -95,7 +96,11 @@ function ResultAttemptsForm({
   }
 
   function confirmSubmission() {
-    const submissionWarning = attemptResultsWarning(attemptResults, eventId);
+    const submissionWarning = attemptResultsWarning(
+      attemptResults,
+      eventId,
+      officialWorldRecords
+    );
 
     if (submissionWarning) {
       return confirm({

--- a/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.js
+++ b/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.js
@@ -48,6 +48,13 @@ const ROUND_QUERY = gql`
         enteredAt
       }
     }
+    officialWorldRecords {
+      event {
+        id
+      }
+      type
+      attemptResult
+    }
   }
 `;
 
@@ -103,7 +110,7 @@ function RoundDoubleCheck() {
 
   if (loading && !data) return <Loading />;
   if (error) return <Error error={error} />;
-  const { round } = data;
+  const { round, officialWorldRecords } = data;
 
   const results = orderBy(
     round.results,
@@ -164,6 +171,7 @@ function RoundDoubleCheck() {
             cutoff={round.cutoff}
             disabled={enterLoading}
             onSubmit={handleResultAttemptsSubmit}
+            officialWorldRecords={officialWorldRecords}
           />
         </Grid>
         <Grid item md sx={{ textAlign: 'center' }}>

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -264,9 +264,8 @@ export function isWorldRecord(
   attemptResult,
   eventId,
   type,
-  officialWorldRecords
+  officialWorldRecords = []
 ) {
-  // if (officialWorldRecords === undefined) return false;
   const wr =
     officialWorldRecords.find(
       (wr) => wr.type === type && wr.event.id === eventId

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -257,10 +257,32 @@ export function autocompleteTimeAttemptResult(time) {
 }
 
 /**
+ * Checks whether a given attempt is a world record of the given type.
+ * Returns the corresponding boolean.
+ */
+export function isWorldRecord(
+  attemptResult,
+  eventId,
+  type,
+  officialWorldRecords
+) {
+  // if (officialWorldRecords === undefined) return false;
+  const wr =
+    officialWorldRecords.find(
+      (wr) => wr.type === type && wr.event.id === eventId
+    ) || null;
+  return wr !== null && attemptResult <= wr.attemptResult;
+}
+
+/**
  * Checks the given attempt results for discrepancies and returns
  * a warning message if some are found.
  */
-export function attemptResultsWarning(attemptResults, eventId) {
+export function attemptResultsWarning(
+  attemptResults,
+  eventId,
+  officialWorldRecords
+) {
   const skippedGapIndex =
     trimTrailingSkipped(attemptResults).indexOf(SKIPPED_VALUE);
   if (skippedGapIndex !== -1) {
@@ -268,24 +290,50 @@ export function attemptResultsWarning(attemptResults, eventId) {
       skippedGapIndex + 1
     }. Make sure it's intentional.`;
   }
-  if (eventId === '333mbf') {
-    const lowTimeIndex = attemptResults.findIndex((attempt) => {
-      const { attempted, centiseconds } = decodeMbldAttemptResult(attempt);
-      return attempt > 0 && centiseconds / attempted < 30 * 100;
-    });
-    if (lowTimeIndex !== -1) {
+  const completeAttempts = attemptResults.filter(isComplete);
+  if (completeAttempts.length > 0) {
+    const bestSingle = Math.min(...completeAttempts);
+    const newWorldRecordSingle = isWorldRecord(
+      bestSingle,
+      eventId,
+      'single',
+      officialWorldRecords
+    );
+    if (newWorldRecordSingle) {
       return `
+          The result you're trying to submit includes a new world record single
+          (${formatAttemptResult(bestSingle, eventId)}).
+          Please check that the results are accurate.
+        `;
+    }
+    if (eventId === '333mbf') {
+      const lowTimeIndex = attemptResults.findIndex((attempt) => {
+        const { attempted, centiseconds } = decodeMbldAttemptResult(attempt);
+        return attempt > 0 && centiseconds / attempted < 30 * 100;
+      });
+      if (lowTimeIndex !== -1) {
+        return `
         The result you're trying to submit seems to be impossible:
         attempt ${lowTimeIndex + 1} is done in
         less than 30 seconds per cube tried.
         If you want to enter minutes, don't forget to add two zeros
         for centiseconds at the end of the score.
       `;
-    }
-  } else {
-    const completeAttempts = attemptResults.filter(isComplete);
-    if (completeAttempts.length > 0) {
-      const bestSingle = Math.min(...completeAttempts);
+      }
+    } else {
+      const newWorldRecordAverage = isWorldRecord(
+        average(attemptResults, eventId),
+        eventId,
+        'average',
+        officialWorldRecords
+      );
+      if (newWorldRecordAverage) {
+        return `
+          The result you're trying to submit is a new world record average
+          (${formatAttemptResult(average(attemptResults, eventId), eventId)}).
+          Please check that the results are accurate.
+        `;
+      }
       const worstSingle = Math.max(...completeAttempts);
       const inconsistent = worstSingle > bestSingle * 4;
       if (inconsistent) {

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -280,7 +280,7 @@ export function isWorldRecord(
 export function attemptResultsWarning(
   attemptResults,
   eventId,
-  officialWorldRecords
+  officialWorldRecords = []
 ) {
   const skippedGapIndex =
     trimTrailingSkipped(attemptResults).indexOf(SKIPPED_VALUE);


### PR DESCRIPTION
Using the API added in `bf89d0f`, world records are now fetched and used to check results for new world records when they are submitted.

There were some considersations when altering the warning logic:

1. The purpose of the warning is to have the user go back and double-check the results. Therefore, it doesn't ultimately matter exactly which warning gets shown to the user, if more than one warning is applicable to a set of results.
2. All events have world record singles, but `333mbf` is the only one without an average. The current code has a branch for `333mbf` warnings, so before it branches off, I check for a WR single. After the branch is taken that no longer includes `333mbf`, I check for a new WR average.
3. Only final results from the WCA database are returned from the query. If a world record is broken multiple times before results are submitted, there will be unnecessary warning dialogs. However, since the warning is simply to detect false positives, it's okay to show the dialog eagerly.
4. This does not check for Continental Records or National Records, as that involves more complex logic and data to check the competitor's country and continent.