### PR TITLE
Improvements to batch result entry

### DIFF
--- a/client/src/components/admin/AdminRound/AdminRoundContent.js
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.js
@@ -22,6 +22,7 @@ import AdminRoundToolbar from './AdminRoundToolbar';
 import { ADMIN_ROUND_RESULT_FRAGMENT } from './fragments';
 import useApolloErrorHandler from '../../../hooks/useApolloErrorHandler';
 import QuitCompetitorDialog from './QuitCompetitorDialog';
+import { nowISOString } from '../../../lib/date';
 
 const ENTER_RESULTS = gql`
   mutation EnterResults($input: EnterResultsInput!) {
@@ -89,13 +90,18 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
     if (isBatchMode) {
       setBatchResults([
         ...batchResults.filter((result) => result.id !== editedResult.id),
-        { id: editedResult.id, attempts },
+        { id: editedResult.id, attempts, enteredAt: nowISOString() },
       ]);
       setEditedResult(null);
     } else {
       enterResults({
         variables: {
-          input: { id: round.id, results: [{ id: editedResult.id, attempts }] },
+          input: {
+            id: round.id,
+            results: [
+              { id: editedResult.id, attempts, enteredAt: nowISOString() },
+            ],
+          },
         },
       });
     }

--- a/client/src/components/admin/AdminRound/AdminRoundContent.js
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.js
@@ -6,10 +6,13 @@ import {
   Checkbox,
   FormControlLabel,
   Grid,
+  IconButton,
   Paper,
   TableContainer,
+  Tooltip,
   Typography,
 } from '@mui/material';
+import ClearIcon from '@mui/icons-material/Clear';
 import { useConfirm } from 'material-ui-confirm';
 import { useSnackbar } from 'notistack';
 import ResultAttemptsForm from '../ResultAttemptsForm/ResultAttemptsForm';
@@ -85,6 +88,14 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
     });
   }
 
+  function discardBatch() {
+    confirm({
+      description: `This will discard all entered results that are currently in the batch.`,
+    }).then(() => {
+      setBatchResults([]);
+    });
+  }
+
   function handleClearResult(result) {
     confirm({
       description: `This will clear all attempts of ${result.person.name}.`,
@@ -149,13 +160,24 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
               label="Batch mode"
             />
             {isBatchMode && (
-              <Grid container direction="row" alignItems="center">
+              <Grid container direction="row" alignItems="center" gap={1}>
                 <Grid item>
                   <Typography>
                     Results in batch: {batchResults.length}
                   </Typography>
                 </Grid>
                 <Grid item flexGrow={1}></Grid>
+                <Grid item>
+                  <Tooltip title="Discard batch" placement="top">
+                    <IconButton
+                      onClick={discardBatch}
+                      size="small"
+                      disabled={batchResults.length === 0}
+                    >
+                      <ClearIcon />
+                    </IconButton>
+                  </Tooltip>
+                </Grid>
                 <Grid item>
                   <Button
                     type="submit"

--- a/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.js
+++ b/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.js
@@ -10,6 +10,7 @@ import ResultAttemptsForm from '../ResultAttemptsForm/ResultAttemptsForm';
 import { orderBy } from '../../../lib/utils';
 import { parseISO } from 'date-fns';
 import useApolloErrorHandler from '../../../hooks/useApolloErrorHandler';
+import { nowISOString } from '../../../lib/date';
 
 const ROUND_QUERY = gql`
   query Round($id: ID!) {
@@ -129,7 +130,13 @@ function RoundDoubleCheck() {
       variables: {
         input: {
           id: round.id,
-          results: [{ id: results[resultIndex].id, attempts }],
+          results: [
+            {
+              id: results[resultIndex].id,
+              attempts,
+              enteredAt: nowISOString(),
+            },
+          ],
         },
       },
     });

--- a/client/src/lib/date.js
+++ b/client/src/lib/date.js
@@ -73,3 +73,10 @@ export function monthAgoDateString() {
   const monthAgo = sub(startOfToday(), { months: 1 });
   return formatISO(monthAgo, { representation: 'date' });
 }
+
+/**
+ * Returns the current date time as ISO string.
+ */
+export function nowISOString() {
+  return new Date().toISOString();
+}

--- a/lib/wca_live_web/resolvers/scoretaking_mutation.ex
+++ b/lib/wca_live_web/resolvers/scoretaking_mutation.ex
@@ -67,7 +67,13 @@ defmodule WcaLiveWeb.Resolvers.ScoretakingMutation do
   # Results
 
   def enter_results(_parent, %{input: input}, %{context: %{current_user: current_user}}) do
-    result_inputs = for input <- input.results, do: {String.to_integer(input.id), input.attempts}
+    result_inputs =
+      for input <- input.results,
+          do: %{
+            id: String.to_integer(input.id),
+            attempts: input.attempts,
+            entered_at: input.entered_at
+          }
 
     with {:ok, round} <- Scoretaking.fetch_round(input.id),
          true <- Scoretaking.Access.can_manage_round?(current_user, round) || @access_denied,

--- a/lib/wca_live_web/schema/scoretaking_mutation_types.ex
+++ b/lib/wca_live_web/schema/scoretaking_mutation_types.ex
@@ -45,11 +45,6 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypes do
     field :id, non_null(:id)
   end
 
-  input_object :enter_result_attempts_input do
-    field :id, non_null(:id)
-    field :attempts, non_null(list_of(non_null(:attempt_input)))
-  end
-
   input_object :enter_results_input do
     field :id, non_null(:id)
     field :results, non_null(list_of(non_null(:result_attempts_input)))
@@ -58,6 +53,7 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypes do
   input_object :result_attempts_input do
     field :id, non_null(:id)
     field :attempts, non_null(list_of(non_null(:attempt_input)))
+    field :entered_at, :datetime
   end
 
   input_object :attempt_input do

--- a/test/wca_live/scoretaking_test.exs
+++ b/test/wca_live/scoretaking_test.exs
@@ -109,8 +109,17 @@ defmodule WcaLive.ScoretakingTest do
     result = insert(:result, round: round, attempts: build_list(3, :attempt, result: 1000))
 
     attrs = [
-      {result.id,
-       [%{result: 900}, %{result: 800}, %{result: 1000}, %{result: 600}, %{result: 700}]}
+      %{
+        id: result.id,
+        attempts: [
+          %{result: 900},
+          %{result: 800},
+          %{result: 1000},
+          %{result: 600},
+          %{result: 700}
+        ],
+        entered_at: DateTime.utc_now()
+      }
     ]
 
     assert {:ok, _round} = Scoretaking.enter_results(round, attrs, user)
@@ -125,8 +134,17 @@ defmodule WcaLive.ScoretakingTest do
     result = insert(:result, round: round, best: 0, average: 0)
 
     attrs = [
-      {result.id,
-       [%{result: 900}, %{result: 800}, %{result: 1000}, %{result: 600}, %{result: 700}]}
+      %{
+        id: result.id,
+        attempts: [
+          %{result: 900},
+          %{result: 800},
+          %{result: 1000},
+          %{result: 600},
+          %{result: 700}
+        ],
+        entered_at: DateTime.utc_now()
+      }
     ]
 
     assert {:ok, _round} = Scoretaking.enter_results(round, attrs, user)
@@ -140,7 +158,7 @@ defmodule WcaLive.ScoretakingTest do
     round = insert(:round, format_id: "1")
     result = insert(:result, round: round, best: 0, average: 0)
 
-    attrs = [{result.id, [%{result: 900}]}]
+    attrs = [%{id: result.id, attempts: [%{result: 900}], entered_at: DateTime.utc_now()}]
 
     assert {:ok, _round} = Scoretaking.enter_results(round, attrs, user)
     result = Repo.reload(result)
@@ -164,7 +182,7 @@ defmodule WcaLive.ScoretakingTest do
 
     result2 = insert(:result, round: round, ranking: nil, attempts: [], advancing: false)
 
-    attrs = [{result2.id, [%{result: 900}]}]
+    attrs = [%{id: result2.id, attempts: [%{result: 900}], entered_at: DateTime.utc_now()}]
 
     assert {:ok, _round} = Scoretaking.enter_results(round, attrs, user)
     result2 = Repo.reload(result2)
@@ -190,8 +208,17 @@ defmodule WcaLive.ScoretakingTest do
       )
 
     attrs = [
-      {result.id,
-       [%{result: 1400}, %{result: 2500}, %{result: 2500}, %{result: 2500}, %{result: 2500}]}
+      %{
+        id: result.id,
+        attempts: [
+          %{result: 1400},
+          %{result: 2500},
+          %{result: 2500},
+          %{result: 2500},
+          %{result: 2500}
+        ],
+        entered_at: DateTime.utc_now()
+      }
     ]
 
     assert {:ok, _round} = Scoretaking.enter_results(round, attrs, user)
@@ -206,7 +233,11 @@ defmodule WcaLive.ScoretakingTest do
     result = insert(:result, round: round, attempts: build_list(3, :attempt, result: 1000))
 
     attrs = [
-      {result.id, [%{result: -2}, %{result: -2}, %{result: -2}, %{result: -2}, %{result: -2}]}
+      %{
+        id: result.id,
+        attempts: [%{result: -2}, %{result: -2}, %{result: -2}, %{result: -2}, %{result: -2}],
+        entered_at: DateTime.utc_now()
+      }
     ]
 
     assert {:error, changeset} = Scoretaking.enter_results(round, attrs, user)
@@ -221,7 +252,13 @@ defmodule WcaLive.ScoretakingTest do
     round = insert(:round, cutoff: nil, format_id: "a")
     result = insert(:result, round: round, attempts: build_list(3, :attempt, result: 1000))
 
-    attrs = [{result.id, [%{result: -2}, %{result: -2}, %{result: -2}]}]
+    attrs = [
+      %{
+        id: result.id,
+        attempts: [%{result: -2}, %{result: -2}, %{result: -2}],
+        entered_at: DateTime.utc_now()
+      }
+    ]
 
     assert {:ok, _updated} = Scoretaking.enter_results(round, attrs, user)
   end
@@ -237,7 +274,9 @@ defmodule WcaLive.ScoretakingTest do
 
     result = insert(:result, round: round, attempts: build_list(3, :attempt, result: 1000))
 
-    attrs = [{result.id, [%{result: -2}, %{result: -2}]}]
+    attrs = [
+      %{id: result.id, attempts: [%{result: -2}, %{result: -2}], entered_at: DateTime.utc_now()}
+    ]
 
     assert {:error, changeset} = Scoretaking.enter_results(round, attrs, user)
 
@@ -253,10 +292,28 @@ defmodule WcaLive.ScoretakingTest do
     result2 = insert(:result, round: round, attempts: build_list(3, :attempt, result: 1000))
 
     attrs = [
-      {result1.id,
-       [%{result: 900}, %{result: 800}, %{result: 1000}, %{result: 600}, %{result: 700}]},
-      {result2.id,
-       [%{result: 901}, %{result: 801}, %{result: 1001}, %{result: 601}, %{result: 701}]}
+      %{
+        id: result1.id,
+        attempts: [
+          %{result: 900},
+          %{result: 800},
+          %{result: 1000},
+          %{result: 600},
+          %{result: 700}
+        ],
+        entered_at: DateTime.utc_now()
+      },
+      %{
+        id: result2.id,
+        attempts: [
+          %{result: 901},
+          %{result: 801},
+          %{result: 1001},
+          %{result: 601},
+          %{result: 701}
+        ],
+        entered_at: DateTime.utc_now()
+      }
     ]
 
     assert {:ok, _round} = Scoretaking.enter_results(round, attrs, user)
@@ -272,7 +329,7 @@ defmodule WcaLive.ScoretakingTest do
     user = insert(:user)
     round = insert(:round)
 
-    attrs = [{111_111_111, []}]
+    attrs = [%{id: 111_111_111, attempts: [], entered_at: DateTime.utc_now()}]
 
     assert {:ok, _round} = Scoretaking.enter_results(round, attrs, user)
   end

--- a/test/wca_live_web/schema/scoretaking_mutation_types_test.exs
+++ b/test/wca_live_web/schema/scoretaking_mutation_types_test.exs
@@ -206,7 +206,8 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypesTest do
               %{"result" => 1300},
               %{"result" => -1},
               %{"result" => 1100}
-            ]
+            ],
+            "enteredAt" => DateTime.utc_now() |> DateTime.to_iso8601()
           }
         ]
       }
@@ -254,7 +255,8 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypesTest do
         "results" => [
           %{
             "id" => to_gql_id(result.id),
-            "attempts" => []
+            "attempts" => [],
+            "enteredAt" => DateTime.utc_now() |> DateTime.to_iso8601()
           }
         ]
       }
@@ -281,7 +283,8 @@ defmodule WcaLiveWeb.Schema.ScoretakingMutationTypesTest do
         "results" => [
           %{
             "id" => to_gql_id(result.id),
-            "attempts" => []
+            "attempts" => [],
+            "enteredAt" => DateTime.utc_now() |> DateTime.to_iso8601()
           }
         ]
       }


### PR DESCRIPTION
Closes #161, closes #162.

Changes:

* batch results are now persisted in local storage to avoid losing on page refresh. Initially I thought about preventing people from navigating/refreshing, but apparently it's not straightforward with react-router
* added a button to discard the batch (since now refresh doesn't discard them)
* we attach submission timestamp on the client, since now it can be deferred until the batch is submitted