### PR TITLE
Cache official records in the database rather than file

### DIFF
--- a/lib/wca_live/storage.ex
+++ b/lib/wca_live/storage.ex
@@ -1,0 +1,43 @@
+defmodule WcaLive.Storage do
+  @moduledoc """
+  Key-value storage persisted in the database.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias WcaLive.Repo
+
+  defmodule Term do
+    use WcaLive.Schema
+
+    @primary_key {:key, :string, []}
+    schema "terms" do
+      field :value, :binary
+    end
+  end
+
+  @doc """
+  Puts the given value in storage under `key`.
+  """
+  @spec put(String.t(), term()) :: :ok | :error
+  def put(key, value) do
+    term = %Term{key: key, value: :erlang.term_to_binary(value)}
+
+    case Repo.insert(term, on_conflict: :replace_all, conflict_target: :key) do
+      {:ok, _} -> :ok
+      {:error, _} -> :error
+    end
+  end
+
+  @doc """
+  Fetches value for the given `key` from storage.
+  """
+  @spec fetch(String.t()) :: {:ok, term()} | :error
+  def fetch(key) do
+    if result = Repo.get(Term, key) do
+      {:ok, :erlang.binary_to_term(result.value)}
+    else
+      :error
+    end
+  end
+end

--- a/lib/wca_live/telemetry.ex
+++ b/lib/wca_live/telemetry.ex
@@ -10,10 +10,10 @@ defmodule WcaLive.Telemetry do
       [:absinthe, :execute, :operation, :stop]
     ]
 
-    :ok = :telemetry.attach_many("wca-live-handler", events, &handle_event/4, %{})
+    :ok = :telemetry.attach_many("wca-live-handler", events, &__MODULE__.handle_event/4, %{})
   end
 
-  defp handle_event([:wca_live, :repo, :query], measurements, metadata, _config) do
+  def handle_event([:wca_live, :repo, :query], measurements, metadata, _config) do
     query_time_ms = System.convert_time_unit(measurements.query_time, :native, :millisecond)
 
     if query_time_ms > @slow_query_threshold_ms do
@@ -29,7 +29,7 @@ defmodule WcaLive.Telemetry do
     end
   end
 
-  defp handle_event([:absinthe, :execute, :operation, :stop], measurements, metadata, _config) do
+  def handle_event([:absinthe, :execute, :operation, :stop], measurements, metadata, _config) do
     duration_ms = System.convert_time_unit(measurements.duration, :native, :millisecond)
 
     if duration_ms > @slow_graphql_threshold_ms do

--- a/priv/repo/migrations/20230730174034_create_terms.exs
+++ b/priv/repo/migrations/20230730174034_create_terms.exs
@@ -1,0 +1,10 @@
+defmodule WcaLive.Repo.Migrations.CreateTerms do
+  use Ecto.Migration
+
+  def change do
+    create table(:terms, primary_key: false) do
+      add :key, :string, null: false, primary_key: true
+      add :value, :binary, null: false
+    end
+  end
+end


### PR DESCRIPTION
We fetch official records from the WCA API every hour and also cache in a file. However, with the new infrastructure, new containers don't have access to that file, so they always make a new request. This is particularly problematic if the WCA API is down, because the containers fail to start.

With this PR we now store records in the database instead, so new containers can always start, even with WCA API being unavailable. It also ensures that if there are multiple nodes, the hourly update happens only once (rather than once per node).