### PR TITLE
[Hotfix] Changed user_role API to /user_roles instead of /user_roles/user/user_id

### DIFF
--- a/lib/wca_live/wca/api.ex
+++ b/lib/wca_live/wca/api.ex
@@ -20,12 +20,13 @@ defmodule WcaLive.Wca.Api do
   def get_active_team_roles(wca_user_id, access_token) do
     params = %{
       "isActive" => true,
-      "groupType" => "teams_committees"
+      "groupType" => "teams_committees",
+      "userId" => wca_user_id
     }
 
     build_req()
     |> with_user_token(access_token)
-    |> request(url: "/user_roles/user/#{wca_user_id}", params: params)
+    |> request(url: "/user_roles", params: params)
   end
 
   @doc """


### PR DESCRIPTION
The user_roles/user/user_id API is now deprecated in favor of a replacement API.