### PR TITLE
Format MBLD results below 1 minute more clearly

### DIFF
--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -267,7 +267,9 @@ function formatMbldAttemptResult(attemptResult) {
     decodeMbldAttemptResult(attemptResult);
   const clockFormat = centisecondsToClockFormat(centiseconds);
   const shortClockFormat = clockFormat.replace(/\.00$/, "");
-  return `${solved}/${attempted} ${shortClockFormat}`;
+  return `${solved}/${attempted} ${
+    centiseconds < 6000 ? `0:${shortClockFormat}` : shortClockFormat
+  }`;
 }
 
 function formatFmAttemptResult(attemptResult) {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/4026757b-32d4-41f0-878f-ce2ae4b4b68e)

After:
![image](https://github.com/user-attachments/assets/2c481cf1-6972-4a77-a5fa-a75a52526ee2)
