### PR TITLE
Introduce distinct markers for results with uncertain advancment

### DIFF
--- a/client/src/components/Competitor/Competitor.jsx
+++ b/client/src/components/Competitor/Competitor.jsx
@@ -21,6 +21,7 @@ const COMPETITOR_QUERY = gql`
         id
         ranking
         advancing
+        advancingQuestionable
         attempts {
           result
         }

--- a/client/src/components/CompetitorResults/CompetitorResultsTable.jsx
+++ b/client/src/components/CompetitorResults/CompetitorResultsTable.jsx
@@ -24,6 +24,10 @@ const styles = {
     color: (theme) => theme.palette.getContrastText(green["A400"]),
     backgroundColor: green["A400"],
   },
+  advancingQuestionable: {
+    color: (theme) => theme.palette.getContrastText(green["A100"]),
+    backgroundColor: green["A100"],
+  },
   roundName: {
     width: { xs: 150, lg: 200 },
   },
@@ -78,6 +82,9 @@ function CompetitorResultsTable({ results, competitionId, onResultClick }) {
                 sx={{
                   ...styles.ranking,
                   ...(result.advancing ? styles.advancing : {}),
+                  ...(result.advancingQuestionable
+                    ? styles.advancingQuestionable
+                    : {}),
                 }}
               >
                 {result.ranking}

--- a/client/src/components/Podiums/Podiums.jsx
+++ b/client/src/components/Podiums/Podiums.jsx
@@ -32,6 +32,7 @@ const PODIUMS_QUERY = gql`
           id
           ranking
           advancing
+          advancingQuestionable
           attempts {
             result
           }

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -40,6 +40,10 @@ const styles = {
     color: (theme) => theme.palette.getContrastText(green["A400"]),
     backgroundColor: green["A400"],
   },
+  advancingQuestionable: {
+    color: (theme) => theme.palette.getContrastText(green["A100"]),
+    backgroundColor: green["A100"],
+  },
   name: {
     width: "22%",
     overflow: "hidden",
@@ -192,6 +196,9 @@ function ResultsProjector({ results, format, eventId, title, exitUrl }) {
                         ...styles.cell,
                         ...styles.ranking,
                         ...(result.advancing ? styles.advancing : {}),
+                        ...(result.advancingQuestionable
+                          ? styles.advancingQuestionable
+                          : {}),
                       }}
                     >
                       {result.ranking}

--- a/client/src/components/Round/Round.jsx
+++ b/client/src/components/Round/Round.jsx
@@ -12,6 +12,7 @@ const ROUND_RESULT_FRAGMENT = gql`
   fragment roundResult on Result {
     ranking
     advancing
+    advancingQuestionable
     attempts {
       result
     }

--- a/client/src/components/RoundResults/RoundResultsTable.jsx
+++ b/client/src/components/RoundResults/RoundResultsTable.jsx
@@ -33,6 +33,10 @@ const styles = {
     color: (theme) => theme.palette.getContrastText(green["A400"]),
     backgroundColor: green["A400"],
   },
+  advancingQuestionable: {
+    color: (theme) => theme.palette.getContrastText(green["A100"]),
+    backgroundColor: green["A100"],
+  },
   name: {
     textOverflow: "ellipsis",
     overflow: "hidden",
@@ -91,6 +95,9 @@ const RoundResultsTable = memo(
                     ...styles.cell,
                     ...styles.ranking,
                     ...(result.advancing ? styles.advancing : {}),
+                    ...(result.advancingQuestionable
+                      ? styles.advancingQuestionable
+                      : {}),
                   }}
                 >
                   {result.ranking}

--- a/client/src/components/admin/AdminRound/AdminResultsTable.jsx
+++ b/client/src/components/admin/AdminRound/AdminResultsTable.jsx
@@ -25,6 +25,10 @@ const styles = {
     color: (theme) => theme.palette.getContrastText(green["A400"]),
     backgroundColor: green["A400"],
   },
+  advancingQuestionable: {
+    color: (theme) => theme.palette.getContrastText(green["A100"]),
+    backgroundColor: green["A100"],
+  },
 };
 
 function sortResults(results, orderBy, order) {
@@ -123,6 +127,9 @@ const AdminResultsTable = memo(
                 sx={{
                   ...styles.ranking,
                   ...(result.advancing ? styles.advancing : {}),
+                  ...(result.advancingQuestionable
+                    ? styles.advancingQuestionable
+                    : {}),
                 }}
               >
                 {result.ranking}

--- a/client/src/components/admin/AdminRound/fragments.jsx
+++ b/client/src/components/admin/AdminRound/fragments.jsx
@@ -6,6 +6,7 @@ export const ADMIN_ROUND_RESULT_FRAGMENT = gql`
   fragment adminRoundResult on Result {
     ranking
     advancing
+    advancingQuestionable
     attempts {
       result
     }

--- a/lib/wca_live/scoretaking/result.ex
+++ b/lib/wca_live/scoretaking/result.ex
@@ -25,6 +25,7 @@ defmodule WcaLive.Scoretaking.Result do
     field :average_record_tag, :string
     field :single_record_tag, :string
     field :advancing, :boolean, default: false
+    field :advancing_questionable, :boolean, default: false
     field :entered_at, :utc_datetime
 
     embeds_many :attempts, Attempt, on_replace: :delete

--- a/lib/wca_live_web/schema/scoretaking_types.ex
+++ b/lib/wca_live_web/schema/scoretaking_types.ex
@@ -109,6 +109,7 @@ defmodule WcaLiveWeb.Schema.ScoretakingTypes do
     field :average_record_tag, :string
     field :single_record_tag, :string
     field :advancing, non_null(:boolean)
+    field :advancing_questionable, non_null(:boolean)
 
     field :attempts, non_null(list_of(non_null(:attempt)))
 

--- a/priv/repo/migrations/20240802124914_add_advancing_questionable_to_results.exs
+++ b/priv/repo/migrations/20240802124914_add_advancing_questionable_to_results.exs
@@ -1,0 +1,9 @@
+defmodule WcaLive.Repo.Migrations.AddAdvancingQuestionableToResults do
+  use Ecto.Migration
+
+  def change do
+    alter table(:results) do
+      add :advancing_questionable, :boolean, null: false, default: false
+    end
+  end
+end


### PR DESCRIPTION
Closes #222. Also closes #128.

An ongoing round looks like this:

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/919c1fd8-f20a-413a-9bda-4858b8e54a4b">

Ranks in the darker green "clinched advancement", while the ones in lighter green qualify as is, but may not advance depending on the remaining results.

I reverted #111 (ignoring empty results in percentage calculation), since those "uncertain" results will now show in the light color.

This change introduces an additional flag to results specifically for the display purpose, so it doesn't affect any of the existing logic.