### PR TITLE
Require the user to type a confirmation keyword when submitting a world record

### DIFF
--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -96,17 +96,16 @@ function ResultAttemptsForm({
   }
 
   function confirmSubmission() {
-    const { description, confirmationKeyword } = attemptResultsWarning(
+    const submissionWarning = attemptResultsWarning(
       attemptResults,
       eventId,
       officialWorldRecords
     );
 
-    if (description) {
+    if (submissionWarning) {
       return confirm({
-        description,
+        ...submissionWarning,
         confirmationText: "Submit",
-        confirmationKeyword,
       });
     } else {
       return Promise.resolve();

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -96,15 +96,15 @@ function ResultAttemptsForm({
   }
 
   function confirmSubmission() {
-    const [submissionWarning, confirmationKeyword] = attemptResultsWarning(
+    const { description, confirmationKeyword } = attemptResultsWarning(
       attemptResults,
       eventId,
       officialWorldRecords
     );
 
-    if (submissionWarning) {
+    if (description) {
       return confirm({
-        description: submissionWarning,
+        description,
         confirmationText: "Submit",
         confirmationKeyword,
       });

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -96,7 +96,7 @@ function ResultAttemptsForm({
   }
 
   function confirmSubmission() {
-    const submissionWarning = attemptResultsWarning(
+    const [submissionWarning, confirmationKeyword] = attemptResultsWarning(
       attemptResults,
       eventId,
       officialWorldRecords
@@ -106,6 +106,7 @@ function ResultAttemptsForm({
       return confirm({
         description: submissionWarning,
         confirmationText: "Submit",
+        confirmationKeyword,
       });
     } else {
       return Promise.resolve();

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -106,6 +106,10 @@ function ResultAttemptsForm({
       return confirm({
         ...submissionWarning,
         confirmationText: "Submit",
+        confirmationKeywordTextFieldProps: {
+          sx: { mt: 2 },
+          autoComplete: "off",
+        },
       });
     } else {
       return Promise.resolve();

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -442,7 +442,7 @@ export function attemptResultsWarning(
       }
     }
   }
-  return {};
+  return null;
 }
 
 /**

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -364,9 +364,10 @@ export function attemptResultsWarning(
   const skippedGapIndex =
     trimTrailingSkipped(attemptResults).indexOf(SKIPPED_VALUE);
   if (skippedGapIndex !== -1) {
-    return [`You've omitted attempt ${
-      skippedGapIndex + 1
-    }. Make sure it's intentional.`];
+    return {
+      description: `You've omitted attempt ${skippedGapIndex + 1
+        }. Make sure it's intentional.`
+    };
   }
   const completeAttempts = attemptResults.filter(isComplete);
   if (completeAttempts.length > 0) {
@@ -378,13 +379,14 @@ export function attemptResultsWarning(
       officialWorldRecords
     );
     if (newWorldRecordSingle) {
-      return [`
-          The result you're trying to submit includes a new world record single
+      return {
+        description: `The result you're trying to submit includes a new world record single
           (${formatAttemptResult(bestSingle, eventId)}).
           Please check that the results are accurate and you are entering for the correct event.
-          Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.
-        `, 'world record'];
-      
+          Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.`,
+        confirmationKeyword: 'world record'
+      };
+
     }
 
     if (shouldComputeAverage(eventId, attemptResults.length)) {
@@ -396,19 +398,20 @@ export function attemptResultsWarning(
       );
 
       if (newWorldRecordAverage) {
-        return [`
-          The result you're trying to submit is a new world record average
-          (${formatAttemptResult(average(attemptResults, eventId), eventId)}).
-          Please check that the results are accurate and you are entering for the correct event.
-          Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.
-        `, 'world record'];
+        return {
+          description: `The result you're trying to submit is a new world record average
+            (${formatAttemptResult(average(attemptResults, eventId), eventId)}).
+            Please check that the results are accurate and you are entering for the correct event.
+            Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.`,
+          confirmationKeyword: 'world record'
+        };
       }
     }
 
     if (checkForDnsFollowedByValidResult(attemptResults)) {
-      return [`
-        There's at least one DNS followed by a valid result. Please ensure it is indeed a DNS and not a DNF.
-      `];
+      return {
+        description: `There's at least one DNS followed by a valid result. Please ensure it is indeed a DNS and not a DNF.`
+      };
     }
 
     if (eventId === "333mbf") {
@@ -417,29 +420,29 @@ export function attemptResultsWarning(
         return attempt > 0 && centiseconds / attempted < 30 * 100;
       });
       if (lowTimeIndex !== -1) {
-        return [`
-        The result you're trying to submit seems to be impossible:
-        attempt ${lowTimeIndex + 1} is done in
-        less than 30 seconds per cube tried.
-        If you want to enter minutes, don't forget to add two zeros
-        for centiseconds at the end of the score.
-      `];
+        return {
+          description: `The result you're trying to submit seems to be impossible:
+            attempt ${lowTimeIndex + 1} is done in
+            less than 30 seconds per cube tried.
+            If you want to enter minutes, don't forget to add two zeros
+            for centiseconds at the end of the score.`
+        };
       }
     } else {
       const worstSingle = Math.max(...completeAttempts);
       const inconsistent = worstSingle > bestSingle * 4;
       if (inconsistent) {
-        return [`
-          The result you're trying to submit seem to be inconsistent.
-          There's a big difference between the best single
-          (${formatAttemptResult(bestSingle, eventId)}) and the worst single
-          (${formatAttemptResult(worstSingle, eventId)}).
-          Please check that the results are accurate.
-        `];
+        return {
+          description: `The result you're trying to submit seem to be inconsistent.
+            There's a big difference between the best single
+            (${formatAttemptResult(bestSingle, eventId)}) and the worst single
+            (${formatAttemptResult(worstSingle, eventId)}).
+            Please check that the results are accurate.`
+        };
       }
     }
   }
-  return [];
+  return {};
 }
 
 /**

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -383,8 +383,9 @@ export function attemptResultsWarning(
       return {
         description: `The result you're trying to submit includes a new world record single
           (${formatAttemptResult(bestSingle, eventId)}).
-          Please check that the results are accurate and you are entering for the correct event.
-          Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.`,
+          Please check that you are entering results for the right event and that all
+          the entered attempts are accurate. Type "world record" below to confirm that
+          you are confident that it is indeed a world record result.`,
         confirmationKeyword: "world record",
       };
     }
@@ -401,8 +402,9 @@ export function attemptResultsWarning(
         return {
           description: `The result you're trying to submit is a new world record average
             (${formatAttemptResult(average(attemptResults, eventId), eventId)}).
-            Please check that the results are accurate and you are entering for the correct event.
-            Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.`,
+            Please check that you are entering results for the right event and that all
+            the entered attempts are accurate. Type "world record" below to confirm that
+            you are confident that it is indeed a world record result.`,
           confirmationKeyword: "world record",
         };
       }

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -364,9 +364,9 @@ export function attemptResultsWarning(
   const skippedGapIndex =
     trimTrailingSkipped(attemptResults).indexOf(SKIPPED_VALUE);
   if (skippedGapIndex !== -1) {
-    return `You've omitted attempt ${
+    return [`You've omitted attempt ${
       skippedGapIndex + 1
-    }. Make sure it's intentional.`;
+    }. Make sure it's intentional.`];
   }
   const completeAttempts = attemptResults.filter(isComplete);
   if (completeAttempts.length > 0) {
@@ -378,11 +378,13 @@ export function attemptResultsWarning(
       officialWorldRecords
     );
     if (newWorldRecordSingle) {
-      return `
+      return [`
           The result you're trying to submit includes a new world record single
           (${formatAttemptResult(bestSingle, eventId)}).
-          Please check that the results are accurate.
-        `;
+          Please check that the results are accurate and you are entering for the correct event.
+          Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.
+        `, 'world record'];
+      
     }
 
     if (shouldComputeAverage(eventId, attemptResults.length)) {
@@ -394,18 +396,19 @@ export function attemptResultsWarning(
       );
 
       if (newWorldRecordAverage) {
-        return `
+        return [`
           The result you're trying to submit is a new world record average
           (${formatAttemptResult(average(attemptResults, eventId), eventId)}).
-          Please check that the results are accurate.
-        `;
+          Please check that the results are accurate and you are entering for the correct event.
+          Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.
+        `, 'world record'];
       }
     }
 
     if (checkForDnsFollowedByValidResult(attemptResults)) {
-      return `
+      return [`
         There's at least one DNS followed by a valid result. Please ensure it is indeed a DNS and not a DNF.
-      `;
+      `];
     }
 
     if (eventId === "333mbf") {
@@ -414,29 +417,29 @@ export function attemptResultsWarning(
         return attempt > 0 && centiseconds / attempted < 30 * 100;
       });
       if (lowTimeIndex !== -1) {
-        return `
+        return [`
         The result you're trying to submit seems to be impossible:
         attempt ${lowTimeIndex + 1} is done in
         less than 30 seconds per cube tried.
         If you want to enter minutes, don't forget to add two zeros
         for centiseconds at the end of the score.
-      `;
+      `];
       }
     } else {
       const worstSingle = Math.max(...completeAttempts);
       const inconsistent = worstSingle > bestSingle * 4;
       if (inconsistent) {
-        return `
+        return [`
           The result you're trying to submit seem to be inconsistent.
           There's a big difference between the best single
           (${formatAttemptResult(bestSingle, eventId)}) and the worst single
           (${formatAttemptResult(worstSingle, eventId)}).
           Please check that the results are accurate.
-        `;
+        `];
       }
     }
   }
-  return null;
+  return [];
 }
 
 /**

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -365,8 +365,9 @@ export function attemptResultsWarning(
     trimTrailingSkipped(attemptResults).indexOf(SKIPPED_VALUE);
   if (skippedGapIndex !== -1) {
     return {
-      description: `You've omitted attempt ${skippedGapIndex + 1
-        }. Make sure it's intentional.`
+      description: `You've omitted attempt ${
+        skippedGapIndex + 1
+      }. Make sure it's intentional.`,
     };
   }
   const completeAttempts = attemptResults.filter(isComplete);
@@ -384,9 +385,8 @@ export function attemptResultsWarning(
           (${formatAttemptResult(bestSingle, eventId)}).
           Please check that the results are accurate and you are entering for the correct event.
           Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.`,
-        confirmationKeyword: 'world record'
+        confirmationKeyword: "world record",
       };
-
     }
 
     if (shouldComputeAverage(eventId, attemptResults.length)) {
@@ -403,14 +403,14 @@ export function attemptResultsWarning(
             (${formatAttemptResult(average(attemptResults, eventId), eventId)}).
             Please check that the results are accurate and you are entering for the correct event.
             Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.`,
-          confirmationKeyword: 'world record'
+          confirmationKeyword: "world record",
         };
       }
     }
 
     if (checkForDnsFollowedByValidResult(attemptResults)) {
       return {
-        description: `There's at least one DNS followed by a valid result. Please ensure it is indeed a DNS and not a DNF.`
+        description: `There's at least one DNS followed by a valid result. Please ensure it is indeed a DNS and not a DNF.`,
       };
     }
 
@@ -425,7 +425,7 @@ export function attemptResultsWarning(
             attempt ${lowTimeIndex + 1} is done in
             less than 30 seconds per cube tried.
             If you want to enter minutes, don't forget to add two zeros
-            for centiseconds at the end of the score.`
+            for centiseconds at the end of the score.`,
         };
       }
     } else {
@@ -437,7 +437,7 @@ export function attemptResultsWarning(
             There's a big difference between the best single
             (${formatAttemptResult(bestSingle, eventId)}) and the worst single
             (${formatAttemptResult(worstSingle, eventId)}).
-            Please check that the results are accurate.`
+            Please check that the results are accurate.`,
         };
       }
     }

--- a/client/src/lib/tests/attempt-result.test.js
+++ b/client/src/lib/tests/attempt-result.test.js
@@ -412,8 +412,7 @@ describe("attemptResultsWarning", () => {
       expect(
         normalize(attemptResultsWarning(attemptResults, "333mbf", worldRecords))
       ).toMatchObject({
-        description:
-          "The result you're trying to submit includes a new world record single (3/4 1:00). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
+        description: `The result you're trying to submit includes a new world record single (3/4 1:00). Please check that you are entering results for the right event and that all the entered attempts are accurate. Type "world record" below to confirm that you are confident that it is indeed a world record result.`,
         confirmationKeyword: "world record",
       });
     });
@@ -473,8 +472,7 @@ describe("attemptResultsWarning", () => {
     expect(
       normalize(attemptResultsWarning(attemptResults, "333", worldRecords))
     ).toMatchObject({
-      description:
-        "The result you're trying to submit includes a new world record single (3.98). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
+      description: `The result you're trying to submit includes a new world record single (3.98). Please check that you are entering results for the right event and that all the entered attempts are accurate. Type "world record" below to confirm that you are confident that it is indeed a world record result.`,
       confirmationKeyword: "world record",
     });
   });
@@ -493,8 +491,7 @@ describe("attemptResultsWarning", () => {
     expect(
       normalize(attemptResultsWarning(attemptResults, "333", worldRecords))
     ).toMatchObject({
-      description:
-        "The result you're trying to submit is a new world record average (5.00). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
+      description: `The result you're trying to submit is a new world record average (5.00). Please check that you are entering results for the right event and that all the entered attempts are accurate. Type "world record" below to confirm that you are confident that it is indeed a world record result.`,
       confirmationKeyword: "world record",
     });
   });

--- a/client/src/lib/tests/attempt-result.test.js
+++ b/client/src/lib/tests/attempt-result.test.js
@@ -421,14 +421,14 @@ describe("attemptResultsWarning", () => {
     });
   });
 
-  it("returns empty object if attempt results do not look suspicious", () => {
+  it("returns null if attempt results do not look suspicious", () => {
     const attemptResults = [900, 1000, 800];
-    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual({});
+    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual(null);
   });
 
   it("does not treat DNF as being far apart from other attempt results", () => {
     const attemptResults = [-1, 1000, 2500];
-    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual({});
+    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual(null);
   });
 
   it("warns about DNS followed by a valid attempt result", () => {
@@ -447,7 +447,7 @@ describe("attemptResultsWarning", () => {
 
   it("does not treat trailing skipped attempt results as omitted", () => {
     const attemptResults = [1000, 0, 0];
-    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual({});
+    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual(null);
   });
 
   it("returns a warning if an attempt breaks a world record single", () => {
@@ -499,7 +499,7 @@ describe("attemptResultsWarning", () => {
         attemptResult: 501,
       },
     ];
-    expect(attemptResultsWarning(attemptResults, "333", worldRecords)).toEqual({});
+    expect(attemptResultsWarning(attemptResults, "333", worldRecords)).toEqual(null);
   });
 
   it("does not check for world record average if there are not enough attempts", () => {
@@ -522,7 +522,7 @@ describe("attemptResultsWarning", () => {
     ];
     expect(
       attemptResultsWarning(attemptResults, "333fm", worldRecords)
-    ).toEqual({});
+    ).toEqual(null);
   });
 });
 

--- a/client/src/lib/tests/attempt-result.test.js
+++ b/client/src/lib/tests/attempt-result.test.js
@@ -379,10 +379,13 @@ describe("isWorldRecord", () => {
 
 describe("attemptResultsWarning", () => {
   const normalize = (obj) =>
-    Object.entries(obj).reduce((acc, [key, value]) => ({
-      ...acc,
-      [key]: value.replace(/\s+/g, " "),
-    }), {});
+    Object.entries(obj).reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key]: value.replace(/\s+/g, " "),
+      }),
+      {}
+    );
 
   describe("when 3x3x3 Multi-Blind attempt results are given", () => {
     it("returns a warning if an attempt has impossibly low time", () => {
@@ -390,7 +393,8 @@ describe("attemptResultsWarning", () => {
       expect(
         normalize(attemptResultsWarning(attemptResults, "333mbf", []))
       ).toMatchObject({
-        description: "The result you're trying to submit seems to be impossible: attempt 2 is done in less than 30 seconds per cube tried. If you want to enter minutes, don't forget to add two zeros for centiseconds at the end of the score."
+        description:
+          "The result you're trying to submit seems to be impossible: attempt 2 is done in less than 30 seconds per cube tried. If you want to enter minutes, don't forget to add two zeros for centiseconds at the end of the score.",
       });
     });
 
@@ -408,7 +412,8 @@ describe("attemptResultsWarning", () => {
       expect(
         normalize(attemptResultsWarning(attemptResults, "333mbf", worldRecords))
       ).toMatchObject({
-        description: "The result you're trying to submit includes a new world record single (3/4 1:00). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
+        description:
+          "The result you're trying to submit includes a new world record single (3/4 1:00). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
         confirmationKeyword: "world record",
       });
     });
@@ -416,8 +421,11 @@ describe("attemptResultsWarning", () => {
 
   it("returns a warning if best and worst attempt results are far apart", () => {
     const attemptResults = [500, 1000, 2500];
-    expect(normalize(attemptResultsWarning(attemptResults, "333", []))).toMatchObject({
-      description: "The result you're trying to submit seem to be inconsistent. There's a big difference between the best single (5.00) and the worst single (25.00). Please check that the results are accurate."
+    expect(
+      normalize(attemptResultsWarning(attemptResults, "333", []))
+    ).toMatchObject({
+      description:
+        "The result you're trying to submit seem to be inconsistent. There's a big difference between the best single (5.00) and the worst single (25.00). Please check that the results are accurate.",
     });
   });
 
@@ -434,14 +442,15 @@ describe("attemptResultsWarning", () => {
   it("warns about DNS followed by a valid attempt result", () => {
     const attemptResults = [2000, DNS_VALUE, 2500, DNF_VALUE, 2000];
     expect(attemptResultsWarning(attemptResults, "333", [])).toMatchObject({
-      description: "There's at least one DNS followed by a valid result. Please ensure it is indeed a DNS and not a DNF."
+      description:
+        "There's at least one DNS followed by a valid result. Please ensure it is indeed a DNS and not a DNF.",
     });
   });
 
   it("returns a warning if an attempt result is omitted", () => {
     const attemptResults = [1000, 0, 900];
     expect(attemptResultsWarning(attemptResults, "333")).toMatchObject({
-      description: "You've omitted attempt 2. Make sure it's intentional."
+      description: "You've omitted attempt 2. Make sure it's intentional.",
     });
   });
 
@@ -464,8 +473,9 @@ describe("attemptResultsWarning", () => {
     expect(
       normalize(attemptResultsWarning(attemptResults, "333", worldRecords))
     ).toMatchObject({
-      description: "The result you're trying to submit includes a new world record single (3.98). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
-      confirmationKeyword: "world record"
+      description:
+        "The result you're trying to submit includes a new world record single (3.98). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
+      confirmationKeyword: "world record",
     });
   });
 
@@ -483,8 +493,9 @@ describe("attemptResultsWarning", () => {
     expect(
       normalize(attemptResultsWarning(attemptResults, "333", worldRecords))
     ).toMatchObject({
-      description: "The result you're trying to submit is a new world record average (5.00). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
-      confirmationKeyword: "world record"
+      description:
+        "The result you're trying to submit is a new world record average (5.00). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
+      confirmationKeyword: "world record",
     });
   });
 
@@ -499,7 +510,9 @@ describe("attemptResultsWarning", () => {
         attemptResult: 501,
       },
     ];
-    expect(attemptResultsWarning(attemptResults, "333", worldRecords)).toEqual(null);
+    expect(attemptResultsWarning(attemptResults, "333", worldRecords)).toEqual(
+      null
+    );
   });
 
   it("does not check for world record average if there are not enough attempts", () => {

--- a/client/src/lib/tests/attempt-result.test.js
+++ b/client/src/lib/tests/attempt-result.test.js
@@ -378,14 +378,20 @@ describe("isWorldRecord", () => {
 });
 
 describe("attemptResultsWarning", () => {
-  const normalize = (string) => string.replace(/\s+/g, " ");
+  const normalize = (obj) =>
+    Object.entries(obj).reduce((acc, [key, value]) => ({
+      ...acc,
+      [key]: value.replace(/\s+/g, " "),
+    }), {});
 
   describe("when 3x3x3 Multi-Blind attempt results are given", () => {
     it("returns a warning if an attempt has impossibly low time", () => {
       const attemptResults = [970360001, 970006001];
       expect(
         normalize(attemptResultsWarning(attemptResults, "333mbf", []))
-      ).toMatch("attempt 2 is done in less than 30 seconds per cube tried");
+      ).toMatchObject({
+        description: "The result you're trying to submit seems to be impossible: attempt 2 is done in less than 30 seconds per cube tried. If you want to enter minutes, don't forget to add two zeros for centiseconds at the end of the score."
+      });
     });
 
     it("returns a warning if an attempt breaks a world record", () => {
@@ -401,46 +407,47 @@ describe("attemptResultsWarning", () => {
       ];
       expect(
         normalize(attemptResultsWarning(attemptResults, "333mbf", worldRecords))
-      ).toMatch(
-        "The result you're trying to submit includes a new world record single (3/4 1:00). Please check that the results are accurate."
-      );
+      ).toMatchObject({
+        description: "The result you're trying to submit includes a new world record single (3/4 1:00). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
+        confirmationKeyword: "world record",
+      });
     });
   });
 
   it("returns a warning if best and worst attempt results are far apart", () => {
     const attemptResults = [500, 1000, 2500];
-    expect(normalize(attemptResultsWarning(attemptResults, "333", []))).toMatch(
-      "There's a big difference between the best single (5.00) and the worst single (25.00)"
-    );
+    expect(normalize(attemptResultsWarning(attemptResults, "333", []))).toMatchObject({
+      description: "The result you're trying to submit seem to be inconsistent. There's a big difference between the best single (5.00) and the worst single (25.00). Please check that the results are accurate."
+    });
   });
 
-  it("returns null if attempt results do not look suspicious", () => {
+  it("returns empty object if attempt results do not look suspicious", () => {
     const attemptResults = [900, 1000, 800];
-    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual(null);
+    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual({});
   });
 
   it("does not treat DNF as being far apart from other attempt results", () => {
     const attemptResults = [-1, 1000, 2500];
-    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual(null);
+    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual({});
   });
 
   it("warns about DNS followed by a valid attempt result", () => {
     const attemptResults = [2000, DNS_VALUE, 2500, DNF_VALUE, 2000];
-    expect(attemptResultsWarning(attemptResults, "333", [])).toMatch(
-      "There's at least one DNS followed by a valid result. Please ensure it is indeed a DNS and not a DNF."
-    );
+    expect(attemptResultsWarning(attemptResults, "333", [])).toMatchObject({
+      description: "There's at least one DNS followed by a valid result. Please ensure it is indeed a DNS and not a DNF."
+    });
   });
 
   it("returns a warning if an attempt result is omitted", () => {
     const attemptResults = [1000, 0, 900];
-    expect(attemptResultsWarning(attemptResults, "333")).toMatch(
-      "You've omitted attempt 2"
-    );
+    expect(attemptResultsWarning(attemptResults, "333")).toMatchObject({
+      description: "You've omitted attempt 2. Make sure it's intentional."
+    });
   });
 
   it("does not treat trailing skipped attempt results as omitted", () => {
     const attemptResults = [1000, 0, 0];
-    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual(null);
+    expect(attemptResultsWarning(attemptResults, "333", [])).toEqual({});
   });
 
   it("returns a warning if an attempt breaks a world record single", () => {
@@ -456,9 +463,10 @@ describe("attemptResultsWarning", () => {
     ];
     expect(
       normalize(attemptResultsWarning(attemptResults, "333", worldRecords))
-    ).toMatch(
-      "The result you're trying to submit includes a new world record single (3.98). Please check that the results are accurate."
-    );
+    ).toMatchObject({
+      description: "The result you're trying to submit includes a new world record single (3.98). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
+      confirmationKeyword: "world record"
+    });
   });
 
   it("returns a warning if the results break the world record average", () => {
@@ -474,9 +482,10 @@ describe("attemptResultsWarning", () => {
     ];
     expect(
       normalize(attemptResultsWarning(attemptResults, "333", worldRecords))
-    ).toMatch(
-      "The result you're trying to submit is a new world record average (5.00). Please check that the results are accurate."
-    );
+    ).toMatchObject({
+      description: "The result you're trying to submit is a new world record average (5.00). Please check that the results are accurate and you are entering for the correct event. Please type 'world record' below to confirm that you have checked and are confident that it is a world record result.",
+      confirmationKeyword: "world record"
+    });
   });
 
   it("does not return a world record warning when average is DNF", () => {
@@ -490,9 +499,7 @@ describe("attemptResultsWarning", () => {
         attemptResult: 501,
       },
     ];
-    expect(attemptResultsWarning(attemptResults, "333", worldRecords)).toEqual(
-      null
-    );
+    expect(attemptResultsWarning(attemptResults, "333", worldRecords)).toEqual({});
   });
 
   it("does not check for world record average if there are not enough attempts", () => {
@@ -515,7 +522,7 @@ describe("attemptResultsWarning", () => {
     ];
     expect(
       attemptResultsWarning(attemptResults, "333fm", worldRecords)
-    ).toEqual(null);
+    ).toEqual({});
   });
 });
 


### PR DESCRIPTION
require data entry to type "world record" for world records since people have clicked through the modal still