### PR TITLE
Add API endpoint to export competition results

### DIFF
--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -58,8 +58,13 @@ defmodule WcaLive.Competitions do
   @spec get_competition_by_wca_id!(String.t()) :: %Competition{}
   def get_competition_by_wca_id!(wca_id), do: Repo.get_by!(Competition, wca_id: wca_id)
 
-  @spec find_competition_by_wca_id!(String.t()) :: %Competition{}
-  def find_competition_by_wca_id!(wca_id), do: Repo.get_by(Competition, wca_id: wca_id)
+  @doc """
+  Gets a single competition by human-readable WCA id.
+
+  Does not raise an error if no competition is found.
+  """
+  @spec find_competition_by_wca_id(String.t()) :: %Competition{}
+  def find_competition_by_wca_id(wca_id), do: Repo.get_by(Competition, wca_id: wca_id)
 
   @doc """
   Gets a single competition.

--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -60,11 +60,9 @@ defmodule WcaLive.Competitions do
 
   @doc """
   Gets a single competition by human-readable WCA id.
-
-  Does not raise an error if no competition is found.
   """
-  @spec find_competition_by_wca_id(String.t()) :: %Competition{}
-  def find_competition_by_wca_id(wca_id), do: Repo.get_by(Competition, wca_id: wca_id)
+  @spec get_competition_by_wca_id(String.t()) :: %Competition{}
+  def get_competition_by_wca_id(wca_id), do: Repo.get_by(Competition, wca_id: wca_id)
 
   @doc """
   Gets a single competition.

--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -71,14 +71,7 @@ defmodule WcaLive.Competitions do
   @spec fetch_competition_by_wca_id(String.t()) ::
           {:ok, %Competition{}} | {:error, Ecto.Queryable.t()}
   def fetch_competition_by_wca_id(id) do
-    Repo.fetch(where(Competition, wca_id: ^wca_id))
-  end
-
-  defp parse_competition_id_or_wca_id(id) do
-    case Integer.parse(id, 10) do
-      {competition_id, ""} -> {:competition_id, competition_id}
-      _ -> {:wca_id, id}
-    end
+    Repo.fetch(where(Competition, wca_id: ^id))
   end
 
   @doc """

--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -58,17 +58,19 @@ defmodule WcaLive.Competitions do
   @spec get_competition_by_wca_id!(String.t()) :: %Competition{}
   def get_competition_by_wca_id!(wca_id), do: Repo.get_by!(Competition, wca_id: wca_id)
 
+  @spec fetch_competition(any()) :: {:error, any()} | {:ok, %{optional(atom()) => any()}}
   @doc """
-  Gets a single competition by human-readable WCA id.
+  Gets a single competition
   """
-  @spec get_competition_by_wca_id(String.t()) :: %Competition{}
-  def get_competition_by_wca_id(wca_id), do: Repo.get_by(Competition, wca_id: wca_id)
+  @spec fetch_competition(term()) :: {:ok, %Competition{}} | {:error, Ecto.Queryable.t()}
+  def fetch_competition(id), do: Repo.fetch(Competition, id)
 
   @doc """
   Gets a single competition by numeric id or wca id
   """
-  @spec fetch_competition(term()) :: {:ok, %Competition{}} | {:error, Ecto.Queryable.t()}
-  def fetch_competition(id) do
+  @spec fetch_competition_by_id_or_wca_id(term()) ::
+          {:ok, %Competition{}} | {:error, Ecto.Queryable.t()}
+  def fetch_competition_by_id_or_wca_id(id) do
     case parse_competition_id_or_wca_id(id) do
       {:competition_id, competition_id} -> Repo.fetch(Competition, competition_id)
       {:wca_id, wca_id} -> Repo.fetch(Ecto.Query.where(Competition, wca_id: ^wca_id))
@@ -76,7 +78,7 @@ defmodule WcaLive.Competitions do
   end
 
   defp parse_competition_id_or_wca_id(id) do
-    case Integer.parse(id) do
+    case Integer.parse(id, 10) do
       {competition_id, ""} -> {:competition_id, competition_id}
       _ -> {:wca_id, id}
     end

--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -66,15 +66,12 @@ defmodule WcaLive.Competitions do
   def fetch_competition(id), do: Repo.fetch(Competition, id)
 
   @doc """
-  Gets a single competition by numeric id or wca id
+  Gets a single competition by WCA id.
   """
-  @spec fetch_competition_by_id_or_wca_id(term()) ::
+  @spec fetch_competition_by_wca_id(String.t()) ::
           {:ok, %Competition{}} | {:error, Ecto.Queryable.t()}
-  def fetch_competition_by_id_or_wca_id(id) do
-    case parse_competition_id_or_wca_id(id) do
-      {:competition_id, competition_id} -> Repo.fetch(Competition, competition_id)
-      {:wca_id, wca_id} -> Repo.fetch(Ecto.Query.where(Competition, wca_id: ^wca_id))
-    end
+  def fetch_competition_by_wca_id(id) do
+    Repo.fetch(where(Competition, wca_id: ^wca_id))
   end
 
   defp parse_competition_id_or_wca_id(id) do

--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -45,7 +45,7 @@ defmodule WcaLive.Competitions do
   end
 
   @doc """
-  Gets a single competition.
+  Gets a single competition by numeric id.
   """
   @spec get_competition(term()) :: %Competition{} | nil
   def get_competition(id), do: Repo.get(Competition, id)
@@ -65,10 +65,22 @@ defmodule WcaLive.Competitions do
   def get_competition_by_wca_id(wca_id), do: Repo.get_by(Competition, wca_id: wca_id)
 
   @doc """
-  Gets a single competition.
+  Gets a single competition by numeric id or wca id
   """
   @spec fetch_competition(term()) :: {:ok, %Competition{}} | {:error, Ecto.Queryable.t()}
-  def fetch_competition(id), do: Repo.fetch(Competition, id)
+  def fetch_competition(id) do
+    case parse_competition_id_or_wca_id(id) do
+      {:competition_id, competition_id} -> Repo.fetch(Competition, competition_id)
+      {:wca_id, wca_id} -> Repo.fetch(Ecto.Query.where(Competition, wca_id: ^wca_id))
+    end
+  end
+
+  defp parse_competition_id_or_wca_id(id) do
+    case Integer.parse(id) do
+      {competition_id, ""} -> {:competition_id, competition_id}
+      _ -> {:wca_id, id}
+    end
+  end
 
   @doc """
   Gets a single person.

--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -58,6 +58,9 @@ defmodule WcaLive.Competitions do
   @spec get_competition_by_wca_id!(String.t()) :: %Competition{}
   def get_competition_by_wca_id!(wca_id), do: Repo.get_by!(Competition, wca_id: wca_id)
 
+  @spec find_competition_by_wca_id!(String.t()) :: %Competition{}
+  def find_competition_by_wca_id!(wca_id), do: Repo.get_by(Competition, wca_id: wca_id)
+
   @doc """
   Gets a single competition.
   """

--- a/lib/wca_live/synchronization/export.ex
+++ b/lib/wca_live/synchronization/export.ex
@@ -13,12 +13,6 @@ defmodule WcaLive.Synchronization.Export do
     |> competition_to_wcif()
   end
 
-  def export_results(competition) do
-    competition
-    |> preload_all()
-    |> competition_to_results()
-  end
-
   # Preloads all the associations necessary for building the whole WCIF.
   defp preload_all(competition) do
     competition
@@ -212,39 +206,6 @@ defmodule WcaLive.Synchronization.Export do
       "endTime" => activity.end_time |> DateTime.to_iso8601(),
       "childActivities" => activity.child_activities |> Enum.map(&activity_to_wcif/1)
       # "scrambleSetId" => nil # ignored for now
-    }
-  end
-
-  defp competition_to_results(competition) do
-    competition.competition_events |> Enum.map(&competition_event_for_results/1)
-  end
-
-  defp competition_event_for_results(competition_event) do
-    %{
-      "id" => competition_event.event_id,
-      "rounds" => competition_event.rounds |> Enum.map(&round_for_results/1)
-    }
-  end
-
-  defp round_for_results(round) do
-    %{
-      "id" => round_wcif_id(round),
-      "roundNumber" => round.number,
-      "cutoff" => round.cutoff && round.cutoff |> cutoff_to_wcif(),
-      "timeLimit" => round.time_limit && round.time_limit |> time_limit_to_wcif(),
-      "results" => round.results |> Enum.map(&format_result/1)
-    }
-  end
-
-  defp format_result(result) do
-    %{
-      "registrantId" => result.person.registrant_id,
-      "personName" => result.person.name,
-      "personId" => result.person.wca_id,
-      "ranking" => result.ranking,
-      "best" => result.best,
-      "average" => result.average,
-      "attempts" => result.attempts |> Enum.map(&attempt_to_wcif/1)
     }
   end
 end

--- a/lib/wca_live/synchronization/export.ex
+++ b/lib/wca_live/synchronization/export.ex
@@ -13,6 +13,12 @@ defmodule WcaLive.Synchronization.Export do
     |> competition_to_wcif()
   end
 
+  def export_results(competition) do
+    competition
+    |> preload_all()
+    |> competition_to_results()
+  end
+
   # Preloads all the associations necessary for building the whole WCIF.
   defp preload_all(competition) do
     competition
@@ -208,4 +214,38 @@ defmodule WcaLive.Synchronization.Export do
       # "scrambleSetId" => nil # ignored for now
     }
   end
+
+  defp competition_to_results(competition) do
+    competition.competition_events |> Enum.map(&competition_event_for_results/1)
+  end
+
+  defp competition_event_for_results(competition_event) do
+    %{
+      "id" => competition_event.event_id,
+      "rounds" => competition_event.rounds |> Enum.map(&round_for_results/1)
+    }
+  end
+
+  defp round_for_results(round) do
+    %{
+      "id" => round_wcif_id(round),
+      "roundNumber" => round.number,
+      "cutoff" => round.cutoff && round.cutoff |> cutoff_to_wcif(),
+      "timeLimit" => round.time_limit && round.time_limit |> time_limit_to_wcif(),
+      "results" => round.results |> Enum.map(&format_result/1)
+    }
+  end
+
+  defp format_result(result) do
+    %{
+      "registrantId" => result.person.registrant_id,
+      "personName" => result.person.name,
+      "personId" => result.person.wca_id,
+      "ranking" => result.ranking,
+      "best" => result.best,
+      "average" => result.average,
+      "attempts" => result.attempts |> Enum.map(&attempt_to_wcif/1),
+    }
+  end
+
 end

--- a/lib/wca_live/synchronization/export.ex
+++ b/lib/wca_live/synchronization/export.ex
@@ -244,7 +244,7 @@ defmodule WcaLive.Synchronization.Export do
       "ranking" => result.ranking,
       "best" => result.best,
       "average" => result.average,
-      "attempts" => result.attempts |> Enum.map(&attempt_to_wcif/1),
+      "attempts" => result.attempts |> Enum.map(&attempt_to_wcif/1)
     }
   end
 

--- a/lib/wca_live/synchronization/export.ex
+++ b/lib/wca_live/synchronization/export.ex
@@ -247,5 +247,4 @@ defmodule WcaLive.Synchronization.Export do
       "attempts" => result.attempts |> Enum.map(&attempt_to_wcif/1)
     }
   end
-
 end

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -34,6 +34,7 @@ defmodule WcaLiveWeb.CompetitionController do
         conn
         |> put_status(200)
         |> json(results)
+
       {:error, _} ->
         conn
         |> put_status(404)

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -202,13 +202,20 @@ defmodule WcaLiveWeb.CompetitionController do
   end
 
   defp competition_to_results(competition) do
+    result_registrant_ids =
+      for competition_event <- competition.competition_events,
+          round <- competition_event.rounds,
+          result <- round.results,
+          do: result.registrant_id,
+          into: MapSet.new()
+
     %{
       events:
         competition.competition_events
-        |> Enum.map(&format_competition_event/1)
-        |> Enum.filter(&(&1["rounds"] != [])),
+        |> Enum.map(&format_competition_event/1),
       persons:
         competition.people
+        |> Enum.filter(& &1.registrant_id in result_registrant_ids)
         |> Enum.map(&format_person/1)
         |> Enum.filter(&(&1["id"] != nil))
     }
@@ -220,7 +227,6 @@ defmodule WcaLiveWeb.CompetitionController do
       "rounds" =>
         competition_event.rounds
         |> Enum.map(&format_round/1)
-        |> Enum.filter(&(&1["results"] != []))
     }
   end
 

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -27,7 +27,8 @@ defmodule WcaLiveWeb.CompetitionController do
   end
 
   def show_results(conn, params) do
-    case Competitions.fetch_competition(params["id"]) do
+    IO.inspect(params)
+    case Competitions.fetch_competition(params["id_or_wca_id"]) do
       {:ok, competition} ->
         results = WcaLive.Synchronization.Export.export_results(competition)
 
@@ -39,14 +40,6 @@ defmodule WcaLiveWeb.CompetitionController do
         conn
         |> put_status(404)
         |> json(%{error: "not found"})
-    end
-  end
-
-  @spec show_competition_id(Plug.Conn.t(), nil | maybe_improper_list() | map()) :: Plug.Conn.t()
-  def show_competition_id(conn, params) do
-    case Competitions.find_competition_by_wca_id!(params["wca_id"]) do
-      nil -> conn |> put_status(404) |> json(%{error: "not found"})
-      competition -> conn |> put_status(200) |> json(%{id: competition.id})
     end
   end
 

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -192,8 +192,7 @@ defmodule WcaLiveWeb.CompetitionController do
     end
   end
 
-  @spec format_results(%Competition{}) :: map()
-  def format_results(competition) do
+  defp format_results(competition) do
     competition
     |> Repo.preload(
       competition_events: [rounds: [:competition_event, results: [:person]]],

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -29,7 +29,6 @@ defmodule WcaLiveWeb.CompetitionController do
   def show_results(conn, params) do
     case Competitions.fetch_competition(params["id"]) do
       {:ok, competition} ->
-
         results = WcaLive.Synchronization.Export.export_results(competition)
 
         conn

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -2,7 +2,6 @@ defmodule WcaLiveWeb.CompetitionController do
   use WcaLiveWeb, :controller
 
   alias WcaLive.{Competitions, Scoretaking, Repo}
-  alias WcaLive.Wcif
   alias WcaLive.Competitions.Competition
 
   def show_wcif(conn, params) do
@@ -31,7 +30,8 @@ defmodule WcaLiveWeb.CompetitionController do
   @spec show_results(Plug.Conn.t(), nil | maybe_improper_list() | map()) :: Plug.Conn.t()
   def show_results(conn, params) do
     IO.inspect(params)
-    case Competitions.fetch_competition(params["id_or_wca_id"]) do
+
+    case Competitions.fetch_competition_by_id_or_wca_id(params["id_or_wca_id"]) do
       {:ok, competition} ->
         results = format_results(competition)
 
@@ -207,8 +207,10 @@ defmodule WcaLiveWeb.CompetitionController do
 
   defp competition_to_results(competition) do
     %{
-
-      events: competition.competition_events |> Enum.map(&format_competition_event/1) |> Enum.filter(&(&1["rounds"] != [])),
+      events:
+        competition.competition_events
+        |> Enum.map(&format_competition_event/1)
+        |> Enum.filter(&(&1["rounds"] != [])),
       persons: competition.people |> Enum.map(&format_person/1)
     }
   end
@@ -216,14 +218,18 @@ defmodule WcaLiveWeb.CompetitionController do
   defp format_competition_event(competition_event) do
     %{
       "eventId" => competition_event.event_id,
-      "rounds" => competition_event.rounds |> Enum.map(&format_round/1) |> Enum.filter(&(&1["results"] != []))
+      "rounds" =>
+        competition_event.rounds
+        |> Enum.map(&format_round/1)
+        |> Enum.filter(&(&1["results"] != []))
     }
   end
 
   defp format_round(round) do
     %{
       "number" => round.number,
-      "results" => round.results |> Enum.map(&format_result/1) |> Enum.filter(&(&1["attempts"] != []))
+      "results" =>
+        round.results |> Enum.map(&format_result/1) |> Enum.filter(&(&1["attempts"] != []))
     }
   end
 

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -28,8 +28,6 @@ defmodule WcaLiveWeb.CompetitionController do
   end
 
   def show_results(conn, params) do
-    IO.inspect(params)
-
     case Competitions.fetch_competition_by_id_or_wca_id(params["id_or_wca_id"]) do
       {:ok, competition} ->
         results = format_results(competition)

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -211,7 +211,10 @@ defmodule WcaLiveWeb.CompetitionController do
         competition.competition_events
         |> Enum.map(&format_competition_event/1)
         |> Enum.filter(&(&1["rounds"] != [])),
-      persons: competition.people |> Enum.map(&format_person/1)
+      persons:
+        competition.people
+        |> Enum.map(&format_person/1)
+        |> Enum.filter(&(&1["id"] != nil))
     }
   end
 

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -216,23 +216,18 @@ defmodule WcaLiveWeb.CompetitionController do
           into: MapSet.new()
 
     %{
-      events:
-        competition.competition_events
-        |> Enum.map(&format_competition_event/1),
+      events: Enum.map(competition.competition_events, &format_competition_event/1),
       persons:
-        competition.people
-        |> Enum.filter(&(&1.registrant_id in result_registrant_ids))
-        |> Enum.map(&format_person/1)
-        |> Enum.filter(&(&1["id"] != nil))
+        for person <- competition.people, person.registrant_id in result_registrant_ids do
+          format_person(person)
+        end
     }
   end
 
   defp format_competition_event(competition_event) do
     %{
       "eventId" => competition_event.event_id,
-      "rounds" =>
-        competition_event.rounds
-        |> Enum.map(&format_round/1)
+      "rounds" => Enum.map(competition_event.rounds, &format_round/1)
     }
   end
 
@@ -240,7 +235,9 @@ defmodule WcaLiveWeb.CompetitionController do
     %{
       "number" => round.number,
       "results" =>
-        round.results |> Enum.map(&format_result/1) |> Enum.filter(&(&1["attempts"] != []))
+        for result <- round.results, result.attempts != [] do
+          format_result(result)
+        end
     }
   end
 

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -26,6 +26,30 @@ defmodule WcaLiveWeb.CompetitionController do
     end
   end
 
+  def show_results(conn, params) do
+    case Competitions.fetch_competition(params["id"]) do
+      {:ok, competition} ->
+
+        results = WcaLive.Synchronization.Export.export_results(competition)
+
+        conn
+        |> put_status(200)
+        |> json(results)
+      {:error, _} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "not found"})
+    end
+  end
+
+  @spec show_competition_id(Plug.Conn.t(), nil | maybe_improper_list() | map()) :: Plug.Conn.t()
+  def show_competition_id(conn, params) do
+    case Competitions.find_competition_by_wca_id!(params["wca_id"]) do
+      nil -> conn |> put_status(404) |> json(%{error: "not found"})
+      competition -> conn |> put_status(200) |> json(%{id: competition.id})
+    end
+  end
+
   def enter_attempt(conn, params) do
     case params do
       %{

--- a/lib/wca_live_web/controllers/competition_controller.ex
+++ b/lib/wca_live_web/controllers/competition_controller.ex
@@ -27,7 +27,6 @@ defmodule WcaLiveWeb.CompetitionController do
     end
   end
 
-  @spec show_results(Plug.Conn.t(), nil | maybe_improper_list() | map()) :: Plug.Conn.t()
   def show_results(conn, params) do
     IO.inspect(params)
 

--- a/lib/wca_live_web/router.ex
+++ b/lib/wca_live_web/router.ex
@@ -47,13 +47,9 @@ defmodule WcaLiveWeb.Router do
   scope "/api", WcaLiveWeb do
     pipe_through :api
 
-    # get comp wcif
     get "/competitions/:id/wcif", CompetitionController, :show_wcif
-    # get comp results
     get "/competitions/:id/results", CompetitionController, :show_results
-    # get comp id from wca id
     get "/competitions/:wca_id/id", CompetitionController, :show_competition_id
-
 
     # Public scoretaking endpoints
     post "/enter-attempt", CompetitionController, :enter_attempt

--- a/lib/wca_live_web/router.ex
+++ b/lib/wca_live_web/router.ex
@@ -48,8 +48,9 @@ defmodule WcaLiveWeb.Router do
     pipe_through :api
 
     get "/competitions/:id/wcif", CompetitionController, :show_wcif
-    get "/competitions/:id/results", CompetitionController, :show_results
-    get "/competitions/:wca_id/id", CompetitionController, :show_competition_id
+
+    # Public results endpoint
+    get "/competitions/:id_or_wca_id/results", CompetitionController, :show_results
 
     # Public scoretaking endpoints
     post "/enter-attempt", CompetitionController, :enter_attempt

--- a/lib/wca_live_web/router.ex
+++ b/lib/wca_live_web/router.ex
@@ -47,7 +47,13 @@ defmodule WcaLiveWeb.Router do
   scope "/api", WcaLiveWeb do
     pipe_through :api
 
+    # get comp wcif
     get "/competitions/:id/wcif", CompetitionController, :show_wcif
+    # get comp results
+    get "/competitions/:id/results", CompetitionController, :show_results
+    # get comp id from wca id
+    get "/competitions/:wca_id/id", CompetitionController, :show_competition_id
+
 
     # Public scoretaking endpoints
     post "/enter-attempt", CompetitionController, :enter_attempt

--- a/test/wca_live_web/controllers/competition_controller_test.exs
+++ b/test/wca_live_web/controllers/competition_controller_test.exs
@@ -17,6 +17,27 @@ defmodule WcaLiveWeb.CompetitionControllerTest do
       assert %{"formatVersion" => "1.0", "id" => "WC2019"} = body
     end
 
+    test "returns error when not signed in", %{conn: conn} do
+      competition = insert(:competition, wca_id: "WC2019")
+
+      conn = get(conn, "/api/competitions/#{competition.id}/wcif")
+
+      body = json_response(conn, 403)
+      assert body == %{"error" => "access denied"}
+    end
+
+    @tag :signed_in
+    test "returns error when not authorized", %{conn: conn} do
+      competition = insert(:competition, wca_id: "WC2019")
+
+      conn = get(conn, "/api/competitions/#{competition.id}/wcif")
+
+      body = json_response(conn, 403)
+      assert body == %{"error" => "access denied"}
+    end
+  end
+
+  describe "show_results" do
     test "returns results for a competition", %{conn: conn} do
       competition = insert(:competition, wca_id: "WC2019")
       competition_event = insert(:competition_event, competition: competition)
@@ -58,25 +79,6 @@ defmodule WcaLiveWeb.CompetitionControllerTest do
                  }
                ]
              }
-    end
-
-    test "returns error when not signed in", %{conn: conn} do
-      competition = insert(:competition, wca_id: "WC2019")
-
-      conn = get(conn, "/api/competitions/#{competition.id}/wcif")
-
-      body = json_response(conn, 403)
-      assert body == %{"error" => "access denied"}
-    end
-
-    @tag :signed_in
-    test "returns error when not authorized", %{conn: conn} do
-      competition = insert(:competition, wca_id: "WC2019")
-
-      conn = get(conn, "/api/competitions/#{competition.id}/wcif")
-
-      body = json_response(conn, 403)
-      assert body == %{"error" => "access denied"}
     end
   end
 

--- a/test/wca_live_web/controllers/competition_controller_test.exs
+++ b/test/wca_live_web/controllers/competition_controller_test.exs
@@ -17,6 +17,48 @@ defmodule WcaLiveWeb.CompetitionControllerTest do
       assert %{"formatVersion" => "1.0", "id" => "WC2019"} = body
     end
 
+    test "returns results for a competition", %{conn: conn} do
+      competition = insert(:competition, wca_id: "WC2019")
+      competition_event = insert(:competition_event, competition: competition)
+      round = insert(:round, competition_event: competition_event)
+      person = insert(:person, competition: competition)
+      result = insert(:result, round: round, person: person)
+
+      conn = get(conn, "/api/competitions/#{competition.id}/results")
+
+      body = json_response(conn, 200)
+
+      assert body == %{
+               "events" => [
+                 %{
+                   "eventId" => "333",
+                   "rounds" => [
+                     %{
+                       "number" => 1,
+                       "results" => [
+                         %{
+                           "attempts" => [900, 900, 900, 900, 900],
+                           "average" => 900,
+                           "best" => 900,
+                           "personId" => result.person.registrant_id,
+                           "ranking" => 1
+                         }
+                       ]
+                     }
+                   ]
+                 }
+               ],
+               "persons" => [
+                 %{
+                   "country" => result.person.country_iso2,
+                   "id" => result.person.registrant_id,
+                   "name" => result.person.name,
+                   "wcaId" => result.person.wca_id
+                 }
+               ]
+             }
+    end
+
     test "returns error when not signed in", %{conn: conn} do
       competition = insert(:competition, wca_id: "WC2019")
 

--- a/test/wca_live_web/controllers/competition_controller_test.exs
+++ b/test/wca_live_web/controllers/competition_controller_test.exs
@@ -23,40 +23,41 @@ defmodule WcaLiveWeb.CompetitionControllerTest do
       round = insert(:round, competition_event: competition_event)
       person = insert(:person, competition: competition)
       result = insert(:result, round: round, person: person)
+      _person_without_result = insert(:person, competition: competition)
 
       conn = get(conn, "/api/competitions/#{competition.id}/results")
 
       body = json_response(conn, 200)
 
       assert body == %{
-               "events" => [
-                 %{
-                   "eventId" => "333",
-                   "rounds" => [
-                     %{
-                       "number" => 1,
-                       "results" => [
-                         %{
-                           "attempts" => [900, 900, 900, 900, 900],
-                           "average" => 900,
-                           "best" => 900,
-                           "personId" => result.person.registrant_id,
-                           "ranking" => 1
-                         }
-                       ]
-                     }
-                   ]
-                 }
-               ],
-               "persons" => [
-                 %{
-                   "country" => result.person.country_iso2,
-                   "id" => result.person.registrant_id,
-                   "name" => result.person.name,
-                   "wcaId" => result.person.wca_id
-                 }
-               ]
-             }
+        "events" => [
+          %{
+            "eventId" => "333",
+            "rounds" => [
+              %{
+                "number" => 1,
+                "results" => [
+                  %{
+                    "attempts" => [900, 900, 900, 900, 900],
+                    "average" => 900,
+                    "best" => 900,
+                    "personId" => result.person.registrant_id,
+                    "ranking" => 1
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "persons" => [
+          %{
+            "country" => result.person.country_iso2,
+            "id" => result.person.registrant_id,
+            "name" => result.person.name,
+            "wcaId" => result.person.wca_id
+          }
+        ]
+      }
     end
 
     test "returns error when not signed in", %{conn: conn} do

--- a/test/wca_live_web/controllers/competition_controller_test.exs
+++ b/test/wca_live_web/controllers/competition_controller_test.exs
@@ -30,34 +30,34 @@ defmodule WcaLiveWeb.CompetitionControllerTest do
       body = json_response(conn, 200)
 
       assert body == %{
-        "events" => [
-          %{
-            "eventId" => "333",
-            "rounds" => [
-              %{
-                "number" => 1,
-                "results" => [
-                  %{
-                    "attempts" => [900, 900, 900, 900, 900],
-                    "average" => 900,
-                    "best" => 900,
-                    "personId" => result.person.registrant_id,
-                    "ranking" => 1
-                  }
-                ]
-              }
-            ]
-          }
-        ],
-        "persons" => [
-          %{
-            "country" => result.person.country_iso2,
-            "id" => result.person.registrant_id,
-            "name" => result.person.name,
-            "wcaId" => result.person.wca_id
-          }
-        ]
-      }
+               "events" => [
+                 %{
+                   "eventId" => "333",
+                   "rounds" => [
+                     %{
+                       "number" => 1,
+                       "results" => [
+                         %{
+                           "attempts" => [900, 900, 900, 900, 900],
+                           "average" => 900,
+                           "best" => 900,
+                           "personId" => result.person.registrant_id,
+                           "ranking" => 1
+                         }
+                       ]
+                     }
+                   ]
+                 }
+               ],
+               "persons" => [
+                 %{
+                   "country" => result.person.country_iso2,
+                   "id" => result.person.registrant_id,
+                   "name" => result.person.name,
+                   "wcaId" => result.person.wca_id
+                 }
+               ]
+             }
     end
 
     test "returns error when not signed in", %{conn: conn} do


### PR DESCRIPTION
It'd be useful to get results periodically as they're being added. This would enable a number of third party apps that make use of live results.