### PR TITLE
Periodically remove old competitions

### DIFF
--- a/lib/wca_live/application.ex
+++ b/lib/wca_live/application.ex
@@ -21,7 +21,9 @@ defmodule WcaLive.Application do
       # Start the Endpoint (http/https)
       WcaLiveWeb.Endpoint,
       # Start the Absinthe Subscription supervisor
-      {Absinthe.Subscription, WcaLiveWeb.Endpoint}
+      {Absinthe.Subscription, WcaLiveWeb.Endpoint},
+      # Start worker to periodically remove old data
+      {WcaLive.DataDeletionWorker, every: [day: 1]}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -8,6 +8,8 @@ defmodule WcaLive.Competitions do
   alias WcaLive.Repo
   alias WcaLive.Competitions.{Competition, Person}
 
+  @competition_deletable_after_days 180
+
   @doc """
   Returns a list of competitions.
 
@@ -111,5 +113,24 @@ defmodule WcaLive.Competitions do
     |> Competition.changeset(attrs)
     |> Ecto.Changeset.cast_assoc(:staff_members)
     |> Repo.update()
+  end
+
+  @doc """
+  Deletes all competitions from before #{@competition_deletable_after_days}
+  days ago.
+
+  Returns the number of deleted competitions.
+  """
+  @spec delete_old_competitions() :: non_neg_integer()
+  def delete_old_competitions() do
+    date = Date.utc_today() |> Date.add(-@competition_deletable_after_days)
+
+    {count, _} =
+      Repo.delete_all(
+        from competition in Competition,
+          where: competition.end_date < ^date
+      )
+
+    count
   end
 end

--- a/lib/wca_live/data_deletion_worker.ex
+++ b/lib/wca_live/data_deletion_worker.ex
@@ -1,0 +1,38 @@
+defmodule WcaLive.DataDeletionWorker do
+  use GenServer
+
+  require Logger
+
+  def start_link(every: every) do
+    GenServer.start_link(__MODULE__, to_timeout(every))
+  end
+
+  @impl true
+  def init(scheduling_interval) do
+    {:ok, scheduling_interval, {:continue, :schedule_next_run}}
+  end
+
+  @impl true
+  def handle_continue(:schedule_next_run, scheduling_interval) do
+    Process.send_after(self(), :run, scheduling_interval)
+
+    {:noreply, scheduling_interval}
+  end
+
+  @impl true
+  def handle_info(:run, scheduling_interval) do
+    delete_old_competitions()
+
+    {:noreply, scheduling_interval, {:continue, :schedule_next_run}}
+  end
+
+  defp delete_old_competitions() do
+    deleted_count = WcaLive.Competitions.delete_old_competitions()
+
+    if deleted_count > 0 do
+      Logger.info("[data deletion] Deleted #{deleted_count} old competitions")
+    else
+      Logger.info("[data deletion] No old competitions to delete")
+    end
+  end
+end

--- a/priv/repo/migrations/20241128025743_change_results_references.exs
+++ b/priv/repo/migrations/20241128025743_change_results_references.exs
@@ -1,0 +1,10 @@
+defmodule WcaLive.Repo.Migrations.ChangeResultsReferences do
+  use Ecto.Migration
+
+  def change do
+    alter table(:results) do
+      modify :person_id, references(:people, on_delete: :delete_all),
+        from: references(:people, on_delete: :nothing)
+    end
+  end
+end

--- a/test/wca_live/competitions_test.exs
+++ b/test/wca_live/competitions_test.exs
@@ -98,6 +98,29 @@ defmodule WcaLive.CompetitionsTest do
     assert ["delegate"] == staff_member.roles
   end
 
+  test "delete_old_competitions/0 deletes competitions from before 180 days ago" do
+    today = Date.utc_today()
+
+    competition_before =
+      insert(:competition, start_date: Date.add(today, -191), end_date: Date.add(today, -190))
+
+    competition_at =
+      insert(:competition, start_date: Date.add(today, -181), end_date: Date.add(today, -180))
+
+    competition_after =
+      insert(:competition, start_date: Date.add(today, -171), end_date: Date.add(today, -170))
+
+    competition_future =
+      insert(:competition, start_date: Date.add(today, 1), end_date: Date.add(today, 1))
+
+    assert Competitions.delete_old_competitions() == 1
+
+    refute Repo.reload(competition_before)
+    assert Repo.reload(competition_at)
+    assert Repo.reload(competition_after)
+    assert Repo.reload(competition_future)
+  end
+
   defp ids(list) do
     list |> Enum.map(& &1.id) |> Enum.sort()
   end


### PR DESCRIPTION
It came up in the past a few times, but I never got to it.

There is no reason to keep old competitions. After results are posted, the data is no longer relevant, and the live results are stored in WCIF anyway. On the other hand, keeping old competitions can make anonymization more work, if the person attended a lot of competitions.

To start slow, I picked a range to keep competitions from past 180 days, we can drop that number in the future.