### PR TITLE
Add page for anonymizing personal data

### DIFF
--- a/client/src/components/Anonymize/Anonymize.jsx
+++ b/client/src/components/Anonymize/Anonymize.jsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { gql, useMutation } from "@apollo/client";
+import { Box, Button, Grid, TextField, Typography } from "@mui/material";
+import { useConfirm } from "material-ui-confirm";
+import { useSnackbar } from "notistack";
+
+import useApolloErrorHandler from "../../hooks/useApolloErrorHandler";
+
+const ANONYMIZE_PERSON_MUTATION = gql`
+  mutation AnonymizePerson($input: AnonymizePersonInput!) {
+    anonymizePerson(input: $input) {
+      competitionCount
+    }
+  }
+`;
+
+function Anonymize() {
+  const [wcaId, setWcaId] = useState("");
+  const confirm = useConfirm();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const apolloErrorHandler = useApolloErrorHandler();
+
+  const [anonymizePerson, { loading }] = useMutation(
+    ANONYMIZE_PERSON_MUTATION,
+    {
+      variables: { input: { wcaId } },
+      onError: apolloErrorHandler,
+      onCompleted: ({ anonymizePerson: { competitionCount } }) => {
+        setWcaId("");
+        enqueueSnackbar(
+          `Anonymized personal data across ${competitionCount} competitions`,
+          { variant: "info" }
+        );
+      },
+    }
+  );
+
+  const anonymize = () => {
+    confirm({
+      description: `
+      Are you sure you want to anonymize personal data for ${wcaId}? Type the WCA ID below to confirm.
+      `,
+      confirmationKeyword: wcaId,
+      confirmationKeywordTextFieldProps: {
+        sx: { mt: 2 },
+        autoComplete: "off",
+      },
+    }).then(anonymizePerson);
+  };
+
+  return (
+    <Box p={{ xs: 2, sm: 3 }}>
+      <Grid container direction="column" spacing={2}>
+        <Grid item>
+          <Typography variant="h5" gutterBottom>
+            Anonymize
+          </Typography>
+          <Typography color="textSecondary">
+            This will anonymize all personal information for person with the
+            given WCA ID, across all competitions stored in the database.
+          </Typography>
+        </Grid>
+        <Grid item>
+          <TextField
+            label="WCA ID"
+            value={wcaId}
+            onChange={(event) => setWcaId(event.target.value.toUpperCase())}
+            inputProps={{ maxLength: 10 }}
+            autoComplete="off"
+          />
+        </Grid>
+        <Grid item>
+          <Button
+            variant="contained"
+            color="primary"
+            disabled={!wcaId || loading}
+            onClick={anonymize}
+          >
+            Anonymize
+          </Button>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}
+
+export default Anonymize;

--- a/client/src/components/DefaultNavigation/DefaultNavigation.jsx
+++ b/client/src/components/DefaultNavigation/DefaultNavigation.jsx
@@ -7,6 +7,7 @@ import About from "../About/About";
 import Error from "../Error/Error";
 import Loading from "../Loading/Loading";
 import Account from "../Account/Account";
+import Anonymize from "../Anonymize/Anonymize";
 import MyCompetitions from "../MyCompetitions/MyCompetitions";
 
 const CURRENT_USER_QUERY = gql`
@@ -17,6 +18,7 @@ const CURRENT_USER_QUERY = gql`
       avatar {
         thumbUrl
       }
+      isAdmin
     }
   }
 `;
@@ -40,6 +42,9 @@ function DefaultNavigation() {
           <Route path="my-competitions" element={<MyCompetitions />} />
         )}
         {currentUser && <Route path="account" element={<Account />} />}
+        {currentUser && currentUser.isAdmin && (
+          <Route path="anonymize" element={<Anonymize />} />
+        )}
         {/* Wait for data before redirecting as the user routes are rendered conditionally. */}
         {loaded && <Route path="*" element={<Navigate to="/" />} />}
       </Routes>

--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -143,4 +143,28 @@ defmodule WcaLive.Competitions do
 
     count
   end
+
+  @doc """
+  Anonymizes personal data corresponding to the given WCA ID across
+  all competitions.
+
+  Returns the number of anonymized competitions.
+  """
+  @spec anonymize_person(String.t()) :: {:ok, non_neg_integer()}
+  def anonymize_person(wca_id) do
+    {count, _} =
+      from(Person, where: [wca_id: ^wca_id])
+      |> Repo.update_all(
+        set: [
+          name: "Anonymous",
+          wca_id: "2000ANON01",
+          country_iso2: "US",
+          gender: "o",
+          email: "anonymous@worldcubeassociation.org",
+          avatar_url: nil
+        ]
+      )
+
+    {:ok, count}
+  end
 end

--- a/lib/wca_live_web/resolvers/accounts.ex
+++ b/lib/wca_live_web/resolvers/accounts.ex
@@ -6,6 +6,10 @@ defmodule WcaLiveWeb.Resolvers.Accounts do
     {:ok, avatar}
   end
 
+  def is_admin(user, _args, _resolution) do
+    {:ok, Accounts.User.admin?(user)}
+  end
+
   def current_user(_parent, _args, %{context: %{current_user: current_user}}) do
     {:ok, current_user}
   end

--- a/lib/wca_live_web/resolvers/competitions_mutation.ex
+++ b/lib/wca_live_web/resolvers/competitions_mutation.ex
@@ -14,4 +14,13 @@ defmodule WcaLiveWeb.Resolvers.CompetitionsMutation do
   end
 
   def update_competition_access(_parent, _args, _resolution), do: {:error, "not authenticated"}
+
+  def anonymize_person(_parent, %{input: input}, %{context: %{current_user: current_user}}) do
+    with true <- WcaLive.Accounts.User.admin?(current_user) || {:error, "access denied"},
+         {:ok, count} <- Competitions.anonymize_person(input.wca_id) do
+      {:ok, %{competition_count: count}}
+    end
+  end
+
+  def anonymize_person(_parent, _args, _resolution), do: {:error, "not authenticated"}
 end

--- a/lib/wca_live_web/schema/accounts_types.ex
+++ b/lib/wca_live_web/schema/accounts_types.ex
@@ -37,6 +37,10 @@ defmodule WcaLiveWeb.Schema.AccountsTypes do
     field :competitors, non_null(list_of(non_null(:person))) do
       resolve dataloader(:db, :people, args: %{competitor: true})
     end
+
+    field :is_admin, non_null(:boolean) do
+      resolve &Resolvers.Accounts.is_admin/3
+    end
   end
 
   @desc "A temporary code generated for quick sign in."

--- a/lib/wca_live_web/schema/competitions_mutation_types.ex
+++ b/lib/wca_live_web/schema/competitions_mutation_types.ex
@@ -8,6 +8,11 @@ defmodule WcaLiveWeb.Schema.CompetitionsMutationTypes do
       arg :input, non_null(:update_competition_access_input)
       resolve &Resolvers.CompetitionsMutation.update_competition_access/3
     end
+
+    field :anonymize_person, non_null(:anonymize_person_payload) do
+      arg :input, non_null(:anonymize_person_input)
+      resolve &Resolvers.CompetitionsMutation.anonymize_person/3
+    end
   end
 
   # Inputs
@@ -23,9 +28,17 @@ defmodule WcaLiveWeb.Schema.CompetitionsMutationTypes do
     field :roles, non_null(list_of(non_null(:string)))
   end
 
+  input_object :anonymize_person_input do
+    field :wca_id, non_null(:string)
+  end
+
   # Payloads
 
   object :update_competition_access_payload do
     field :competition, :competition
+  end
+
+  object :anonymize_person_payload do
+    field :competition_count, non_null(:integer)
   end
 end

--- a/test/wca_live_web/schema/competitions_mutation_types_test.exs
+++ b/test/wca_live_web/schema/competitions_mutation_types_test.exs
@@ -3,6 +3,8 @@ defmodule WcaLiveWeb.Schema.CompetitonsMutationTypesTest do
 
   import WcaLive.Factory
 
+  alias WcaLive.Repo
+
   describe "mutation: update competition access" do
     @update_competition_access_mutation """
     mutation UpdateCompetitionAccess($input: UpdateCompetitionAccessInput!) {
@@ -126,6 +128,80 @@ defmodule WcaLiveWeb.Schema.CompetitonsMutationTypesTest do
       body = json_response(conn, 200)
 
       assert %{"errors" => [%{"message" => "access denied"}]} = body
+    end
+  end
+
+  describe "mutation: anonymize person" do
+    @anonymize_person_mutation """
+    mutation AnonymizePerson($input: AnonymizePersonInput!) {
+      anonymizePerson(input: $input) {
+        competitionCount
+      }
+    }
+    """
+
+    @tag signed_in: :admin
+    test "anonymizes person by wca id across all competitions", %{conn: conn} do
+      person1_comp1 = insert(:person, wca_id: "2015HOLM01")
+      person1_comp2 = insert(:person, wca_id: "2015HOLM01")
+      person2 = insert(:person, wca_id: "2016HOLM01")
+
+      input = %{
+        "wcaId" => "2015HOLM01"
+      }
+
+      conn =
+        post(conn, "/api", %{
+          "query" => @anonymize_person_mutation,
+          "variables" => %{"input" => input}
+        })
+
+      body = json_response(conn, 200)
+
+      assert %{"data" => %{"anonymizePerson" => %{"competitionCount" => 2}}} == body
+
+      assert %{
+               name: "Anonymous",
+               wca_id: "2000ANON01",
+               country_iso2: "US",
+               gender: "o",
+               email: "anonymous@worldcubeassociation.org",
+               avatar_url: nil
+             } = Repo.reload(person1_comp1)
+
+      assert %{
+               name: "Anonymous",
+               wca_id: "2000ANON01",
+               country_iso2: "US",
+               gender: "o",
+               email: "anonymous@worldcubeassociation.org",
+               avatar_url: nil
+             } = Repo.reload(person1_comp2)
+
+      assert Repo.reload(person2).name == person2.name
+    end
+
+    @tag :signed_in
+    test "returns an error when not authorized", %{conn: conn} do
+      person1 = insert(:person, wca_id: "2015HOLM01")
+      person2 = insert(:person, wca_id: "2016HOLM01")
+
+      input = %{
+        "wcaId" => "2015HOLM01"
+      }
+
+      conn =
+        post(conn, "/api", %{
+          "query" => @anonymize_person_mutation,
+          "variables" => %{"input" => input}
+        })
+
+      body = json_response(conn, 200)
+
+      assert %{"errors" => [%{"message" => "access denied"}]} = body
+
+      assert Repo.reload(person1).name == person1.name
+      assert Repo.reload(person2).name == person2.name
     end
   end
 end


### PR DESCRIPTION
Streamlines anonymization to not require synchronizing individual competitions.