### PR TITLE
Remove competitions after 90 days

### DIFF
--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -8,7 +8,7 @@ defmodule WcaLive.Competitions do
   alias WcaLive.Repo
   alias WcaLive.Competitions.{Competition, Person}
 
-  @competition_deletable_after_days 180
+  @competition_deletable_after_days 90
 
   @doc """
   Returns a list of competitions.

--- a/test/wca_live/competitions_test.exs
+++ b/test/wca_live/competitions_test.exs
@@ -102,13 +102,13 @@ defmodule WcaLive.CompetitionsTest do
     today = Date.utc_today()
 
     competition_before =
-      insert(:competition, start_date: Date.add(today, -191), end_date: Date.add(today, -190))
+      insert(:competition, start_date: Date.add(today, -101), end_date: Date.add(today, -100))
 
     competition_at =
-      insert(:competition, start_date: Date.add(today, -181), end_date: Date.add(today, -180))
+      insert(:competition, start_date: Date.add(today, -91), end_date: Date.add(today, -90))
 
     competition_after =
-      insert(:competition, start_date: Date.add(today, -171), end_date: Date.add(today, -170))
+      insert(:competition, start_date: Date.add(today, -81), end_date: Date.add(today, -80))
 
     competition_future =
       insert(:competition, start_date: Date.add(today, 1), end_date: Date.add(today, 1))


### PR DESCRIPTION
I believe 90 days is enough. This also matches the requirement for Delegates to keep scorecards for 90 days.

This way WRT has less competitions to synchronize during anonymization.