### PR TITLE
Handle leading/trailing spaces in search input

### DIFF
--- a/client/src/components/CompetitionSearch/CompetitionSearch.jsx
+++ b/client/src/components/CompetitionSearch/CompetitionSearch.jsx
@@ -27,8 +27,7 @@ function CompetitionSearch({ value = null, onChange, TextFieldProps = {} }) {
 
   function handleInputChange(event, value, reason) {
     if (reason === "input") {
-      const sanitizedValue = value.replace(/^\s+/, "").replace(/\s{2,}/g, " ");
-      setSearch(sanitizedValue);
+      setSearch(value);
     }
   }
 
@@ -50,8 +49,8 @@ function CompetitionSearch({ value = null, onChange, TextFieldProps = {} }) {
       onChange={handleChange}
       forcePopupIcon={false}
       disableClearable={true}
-      inputValue={search}
       renderInput={(params) => <TextField {...params} {...TextFieldProps} />}
+      filterOptions={(options) => options}
     />
   );
 }

--- a/client/src/components/CompetitionSearch/CompetitionSearch.jsx
+++ b/client/src/components/CompetitionSearch/CompetitionSearch.jsx
@@ -27,7 +27,8 @@ function CompetitionSearch({ value = null, onChange, TextFieldProps = {} }) {
 
   function handleInputChange(event, value, reason) {
     if (reason === "input") {
-      setSearch(value);
+      const sanitizedValue = value.replace(/^\s+/, "").replace(/\s{2,}/g, " ");
+      setSearch(sanitizedValue);
     }
   }
 
@@ -49,6 +50,7 @@ function CompetitionSearch({ value = null, onChange, TextFieldProps = {} }) {
       onChange={handleChange}
       forcePopupIcon={false}
       disableClearable={true}
+      inputValue={search}
       renderInput={(params) => <TextField {...params} {...TextFieldProps} />}
     />
   );

--- a/lib/wca_live/competitions.ex
+++ b/lib/wca_live/competitions.ex
@@ -35,6 +35,7 @@ defmodule WcaLive.Competitions do
   defp filter_by_text(query, nil), do: query
 
   defp filter_by_text(query, filter) do
+    filter = filter |> String.trim() |> String.replace(~r/\s+/, " ")
     from c in query, where: ilike(c.name, ^"%#{filter}%")
   end
 

--- a/test/wca_live/competitions_test.exs
+++ b/test/wca_live/competitions_test.exs
@@ -28,6 +28,7 @@ defmodule WcaLive.CompetitionsTest do
     assert worlds.id in ids(list)
     assert open.id not in ids(list)
     assert euro.id in ids(list)
+
     list = Competitions.list_competitions(%{filter: " championship  2022  "})
 
     assert worlds.id in ids(list)

--- a/test/wca_live/competitions_test.exs
+++ b/test/wca_live/competitions_test.exs
@@ -28,26 +28,7 @@ defmodule WcaLive.CompetitionsTest do
     assert worlds.id in ids(list)
     assert open.id not in ids(list)
     assert euro.id in ids(list)
-  end
-
-  test "list_competitions/1 given :filter with leading space matches competitions by name" do
-    worlds = insert(:competition, name: "World Championship 2020")
-    open = insert(:competition, name: "WHAT Open 2020")
-    euro = insert(:competition, name: "Euro Championship 2020")
-
-    list = Competitions.list_competitions(%{filter: " World"})
-
-    assert worlds.id in ids(list)
-    assert open.id not in ids(list)
-    assert euro.id not in ids(list)
-  end
-
-  test "list_competitions/1 given :filter with trailing space matches competitions by name" do
-    worlds = insert(:competition, name: "World Championship 2020")
-    open = insert(:competition, name: "WHAT Open 2020")
-    euro = insert(:competition, name: "Euro Championship 2020")
-
-    list = Competitions.list_competitions(%{filter: "Championship  "})
+    list = Competitions.list_competitions(%{filter: " championship  2022  "})
 
     assert worlds.id in ids(list)
     assert open.id not in ids(list)

--- a/test/wca_live/competitions_test.exs
+++ b/test/wca_live/competitions_test.exs
@@ -30,6 +30,30 @@ defmodule WcaLive.CompetitionsTest do
     assert euro.id in ids(list)
   end
 
+  test "list_competitions/1 given :filter with leading space matches competitions by name" do
+    worlds = insert(:competition, name: "World Championship 2020")
+    open = insert(:competition, name: "WHAT Open 2020")
+    euro = insert(:competition, name: "Euro Championship 2020")
+
+    list = Competitions.list_competitions(%{filter: " World"})
+
+    assert worlds.id in ids(list)
+    assert open.id not in ids(list)
+    assert euro.id not in ids(list)
+  end
+
+  test "list_competitions/1 given :filter with trailing space matches competitions by name" do
+    worlds = insert(:competition, name: "World Championship 2020")
+    open = insert(:competition, name: "WHAT Open 2020")
+    euro = insert(:competition, name: "Euro Championship 2020")
+
+    list = Competitions.list_competitions(%{filter: "Championship  "})
+
+    assert worlds.id in ids(list)
+    assert open.id not in ids(list)
+    assert euro.id in ids(list)
+  end
+
   test "list_competitions/1 given :from returns competitions from that date inclusive" do
     first = insert(:competition, start_date: ~D[2020-01-10])
     second = insert(:competition, start_date: ~D[2020-04-20])

--- a/test/wca_live/competitions_test.exs
+++ b/test/wca_live/competitions_test.exs
@@ -29,7 +29,7 @@ defmodule WcaLive.CompetitionsTest do
     assert open.id not in ids(list)
     assert euro.id in ids(list)
 
-    list = Competitions.list_competitions(%{filter: " championship  2022  "})
+    list = Competitions.list_competitions(%{filter: " championship  2020  "})
 
     assert worlds.id in ids(list)
     assert open.id not in ids(list)


### PR DESCRIPTION
It's very annoying when you paste a competition name that accidentally has a space before the actual name, causing the search to fail. The same issue occurs if there are, for example, two spaces between words. 

After these changes, it's no longer possible to start a search with a space or type multiple consecutive spaces. I couldn't find a better solution to this, if anyone has suggestions feel free to comment on this PR.