### PR TITLE
Add "For First" and "For Third" columns to forecast view

### DIFF
--- a/client/src/components/ResultStat/ResultStat.jsx
+++ b/client/src/components/ResultStat/ResultStat.jsx
@@ -57,7 +57,9 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
       return (
         <Box component="span" sx={{ opacity: 0.5 }}>
           <Tooltip title="Projected average">
-            <span>{formatAttemptResultForN(result.projectedAverage, eventId)}</span>
+            <span>
+              {formatAttemptResultForN(result.projectedAverage, eventId)}
+            </span>
           </Tooltip>
         </Box>
       );

--- a/client/src/components/ResultStat/ResultStat.jsx
+++ b/client/src/components/ResultStat/ResultStat.jsx
@@ -2,7 +2,6 @@ import { Box, Tooltip } from "@mui/material";
 import {
   bestPossibleAverage,
   worstPossibleAverage,
-  formatAttemptResult,
   incompleteMean,
 } from "../../lib/attempt-result";
 import {

--- a/client/src/components/ResultStat/ResultStat.jsx
+++ b/client/src/components/ResultStat/ResultStat.jsx
@@ -5,7 +5,10 @@ import {
   formatAttemptResult,
   incompleteMean,
 } from "../../lib/attempt-result";
-import { shouldComputeAverage } from "../../lib/result";
+import {
+  shouldComputeAverage,
+  formatAttemptResultForN,
+} from "../../lib/result";
 
 function ResultStat({ result, field, eventId, format, forecastView }) {
   if (
@@ -22,7 +25,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
             <>
               <Tooltip title="Projected average">
                 <span>
-                  {formatAttemptResult(result.projectedAverage, eventId)}
+                  {formatAttemptResultForN(result.projectedAverage, eventId)}
                 </span>
               </Tooltip>
               {" ("}
@@ -30,7 +33,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
           )}
           <Tooltip title="Best possible average">
             <span>
-              {formatAttemptResult(
+              {formatAttemptResultForN(
                 bestPossibleAverage(attemptResults),
                 eventId
               )}
@@ -39,7 +42,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
           {" / "}
           <Tooltip title="Worst possible average">
             <span>
-              {formatAttemptResult(
+              {formatAttemptResultForN(
                 worstPossibleAverage(attemptResults),
                 eventId
               )}
@@ -54,7 +57,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
       return (
         <Box component="span" sx={{ opacity: 0.5 }}>
           <Tooltip title="Projected average">
-            <span>{formatAttemptResult(result.projectedAverage, eventId)}</span>
+            <span>{formatAttemptResultForN(result.projectedAverage, eventId)}</span>
           </Tooltip>
         </Box>
       );
@@ -65,7 +68,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
         <Box component="span" sx={{ opacity: 0.5 }}>
           <Tooltip title="Mean after 2 solves">
             <span>
-              {formatAttemptResult(
+              {formatAttemptResultForN(
                 incompleteMean(attemptResults, eventId),
                 eventId
               )}
@@ -76,7 +79,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
     }
   }
 
-  return formatAttemptResult(result[field], eventId);
+  return formatAttemptResultForN(result[field], eventId);
 }
 
 export default ResultStat;

--- a/client/src/components/ResultStat/ResultStat.jsx
+++ b/client/src/components/ResultStat/ResultStat.jsx
@@ -6,7 +6,7 @@ import {
 } from "../../lib/attempt-result";
 import {
   shouldComputeAverage,
-  formatAttemptResultForN,
+  formatAttemptResultForView,
 } from "../../lib/result";
 
 function ResultStat({ result, field, eventId, format, forecastView }) {
@@ -24,7 +24,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
             <>
               <Tooltip title="Projected average">
                 <span>
-                  {formatAttemptResultForN(result.projectedAverage, eventId)}
+                  {formatAttemptResultForView(result.projectedAverage, eventId)}
                 </span>
               </Tooltip>
               {" ("}
@@ -32,7 +32,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
           )}
           <Tooltip title="Best possible average">
             <span>
-              {formatAttemptResultForN(
+              {formatAttemptResultForView(
                 bestPossibleAverage(attemptResults),
                 eventId
               )}
@@ -41,7 +41,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
           {" / "}
           <Tooltip title="Worst possible average">
             <span>
-              {formatAttemptResultForN(
+              {formatAttemptResultForView(
                 worstPossibleAverage(attemptResults),
                 eventId
               )}
@@ -57,7 +57,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
         <Box component="span" sx={{ opacity: 0.5 }}>
           <Tooltip title="Projected average">
             <span>
-              {formatAttemptResultForN(result.projectedAverage, eventId)}
+              {formatAttemptResultForView(result.projectedAverage, eventId)}
             </span>
           </Tooltip>
         </Box>
@@ -69,7 +69,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
         <Box component="span" sx={{ opacity: 0.5 }}>
           <Tooltip title="Mean after 2 solves">
             <span>
-              {formatAttemptResultForN(
+              {formatAttemptResultForView(
                 incompleteMean(attemptResults, eventId),
                 eventId
               )}
@@ -80,7 +80,7 @@ function ResultStat({ result, field, eventId, format, forecastView }) {
     }
   }
 
-  return formatAttemptResultForN(result[field], eventId);
+  return formatAttemptResultForView(result[field], eventId);
 }
 
 export default ResultStat;

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -87,7 +87,7 @@ function ResultsProjector({
   const [status, setStatus] = useState(STATUS.SHOWING);
   const [topResultIndex, setTopResultIndex] = useState(0);
 
-  const stats = orderedResultStats(eventId, format);
+  const stats = orderedResultStats(eventId, format, forecastView);
   const nonemptyResults = resultsForView(results, format, forecastView).filter(
     (result) => result.attempts.length > 0
   );

--- a/client/src/components/RoundResults/RoundResultsTable.jsx
+++ b/client/src/components/RoundResults/RoundResultsTable.jsx
@@ -62,7 +62,7 @@ const RoundResultsTable = memo(
     const smScreen = useMediaQuery((theme) => theme.breakpoints.up("sm"));
     const mdScreen = useMediaQuery((theme) => theme.breakpoints.up("md"));
 
-    const stats = orderedResultStats(eventId, format);
+    const stats = orderedResultStats(eventId, format, forecastView);
 
     const viewResults = resultsForView(results, format, forecastView);
     return (

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -4,8 +4,6 @@ import { shouldComputeAverage } from "./result";
 export const SKIPPED_VALUE = 0;
 export const DNF_VALUE = -1;
 export const DNS_VALUE = -2;
-export const NA_VALUE = -3;
-export const SUCCESS_VALUE = -4;
 
 export function isComplete(attemptResult) {
   return attemptResult > 0;
@@ -305,8 +303,6 @@ export function formatAttemptResult(attemptResult, eventId) {
   if (attemptResult === SKIPPED_VALUE) return "";
   if (attemptResult === DNF_VALUE) return "DNF";
   if (attemptResult === DNS_VALUE) return "DNS";
-  if (attemptResult === NA_VALUE) return "N/A";
-  if (attemptResult === SUCCESS_VALUE) return "SUCCESS";
   if (eventId === "333mbf") return formatMbldAttemptResult(attemptResult);
   if (eventId === "333fm") return formatFmAttemptResult(attemptResult);
   return centisecondsToClockFormat(attemptResult);

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -179,8 +179,9 @@ export function projectedAverage(attemptResults, format) {
   throw new Error("Unexpected format");
 }
 
+// Needs to assume inputs are all valid (remove function sumOfX)
 export function countingSum(attemptResults, format) {
-  if (attemptResults.length === 0) return Infinity;
+  if (attemptResults.length === 0) return 0;
 
   if (format.numberOfAttempts === 3) {
     return sumOfX(attemptResults);

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -124,16 +124,11 @@ function meanOfX(attemptResults) {
   return mean(attemptResults);
 }
 
-function sumOfX(attemptResults) {
-  if (!attemptResults.every(isComplete)) return DNF_VALUE;
-  return sum(attemptResults);
-}
-
 function mean(values) {
   return Math.round(sum(values) / values.length);
 }
 
-function sum(values) {
+export function sum(values) {
   return values.reduce((x, y) => x + y, 0);
 }
 
@@ -174,33 +169,6 @@ export function projectedAverage(attemptResults, format) {
       return meanOfX([x, y]);
     }
     return averageOf5(attemptResults);
-  }
-
-  throw new Error("Unexpected format");
-}
-
-// Needs to assume inputs are all valid (remove function sumOfX)
-export function countingSum(attemptResults, format) {
-  if (attemptResults.length === 0) return 0;
-
-  if (format.numberOfAttempts === 3) {
-    return sumOfX(attemptResults);
-  }
-
-  if (format.numberOfAttempts === 5) {
-    if (attemptResults.length < 3) {
-      return sumOfX(attemptResults);
-    }
-    if (attemptResults.length === 3) {
-      const [, x] = attemptResults.slice().sort(compareAttemptResults);
-      return x;
-    }
-    if (attemptResults.length === 4) {
-      const [, x, y] = attemptResults.slice().sort(compareAttemptResults);
-      return sumOfX([x, y]);
-    }
-    const [, x, y, z] = attemptResults.slice().sort(compareAttemptResults);
-    return sumOfX([x, y, z]);
   }
 
   throw new Error("Unexpected format");

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -5,6 +5,7 @@ export const SKIPPED_VALUE = 0;
 export const DNF_VALUE = -1;
 export const DNS_VALUE = -2;
 export const NA_VALUE = -3;
+export const SUCCESS_VALUE = -4;
 
 export function isComplete(attemptResult) {
   return attemptResult > 0;
@@ -18,7 +19,7 @@ export function toMonotonic(attemptResult) {
   return isComplete(attemptResult) ? attemptResult : Infinity;
 }
 
-function compareAttemptResults(attemptResult1, attemptResult2) {
+export function compareAttemptResults(attemptResult1, attemptResult2) {
   if (!isComplete(attemptResult1) && !isComplete(attemptResult2)) return 0;
   if (!isComplete(attemptResult1) && isComplete(attemptResult2)) return 1;
   if (isComplete(attemptResult1) && !isComplete(attemptResult2)) return -1;
@@ -125,11 +126,8 @@ function meanOfX(attemptResults) {
 }
 
 function mean(values) {
-  return Math.round(sum(values) / values.length);
-}
-
-export function sum(values) {
-  return values.reduce((x, y) => x + y, 0);
+  const sum = values.reduce((x, y) => x + y, 0);
+  return Math.round(sum / values.length);
 }
 
 /**
@@ -308,6 +306,7 @@ export function formatAttemptResult(attemptResult, eventId) {
   if (attemptResult === DNF_VALUE) return "DNF";
   if (attemptResult === DNS_VALUE) return "DNS";
   if (attemptResult === NA_VALUE) return "N/A";
+  if (attemptResult === SUCCESS_VALUE) return "SUCCESS";
   if (eventId === "333mbf") return formatMbldAttemptResult(attemptResult);
   if (eventId === "333fm") return formatFmAttemptResult(attemptResult);
   return centisecondsToClockFormat(attemptResult);

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -86,7 +86,7 @@ export function forecastViewSupported(round) {
  * Wrapper for formatAttemptResult. Also handles values
  * NA_VALUE and SUCCESS_VALUE
  */
-export function formatAttemptResultForN(attemptResult, eventId) {
+export function formatAttemptResultForView(attemptResult, eventId) {
   if (attemptResult === NA_VALUE) return "N/A";
   if (attemptResult === SUCCESS_VALUE) return "SUCCESS";
   return formatAttemptResult(attemptResult, eventId);

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -157,7 +157,7 @@ export function resultsForView(results, format, forecastView) {
 
     prevResult = currentResult;
   }
-  
+
   if (resultsForView.length > 1) {
     for (let i = 0; i < resultsForView.length; i++) {
       let result = resultsForView[i];
@@ -183,7 +183,7 @@ export function resultsForView(results, format, forecastView) {
       }
     }
   }
-  
+
   return resultsForView;
 }
 
@@ -191,17 +191,20 @@ function timeNeededToOvertake(result, format, overtakeResult) {
   if (isSkipped(overtakeResult.projectedAverage)) return DNF_VALUE;
 
   let attemptResults = result.attempts.map((attempt) => attempt.result);
-  const resultWorst = attemptResults
-    .slice()
-    .sort(compareAttemptResults)
-    .pop();
+  const resultWorst = attemptResults.slice().sort(compareAttemptResults).pop();
 
   if (attemptResults.length === 2 && format.numberOfAttempts === 5) {
     // Projection will change from a mean to a median after a time is added
-    if (isComplete(resultWorst) && compareAttemptResults(resultWorst, overtakeResult.projectedAverage) < 0) {
+    if (
+      isComplete(resultWorst) &&
+      compareAttemptResults(resultWorst, overtakeResult.projectedAverage) < 0
+    ) {
       return DNF_VALUE;
     }
-    if (isComplete(result.best) && compareAttemptResults(result.best, overtakeResult.projectedAverage) < 0) {
+    if (
+      isComplete(result.best) &&
+      compareAttemptResults(result.best, overtakeResult.projectedAverage) < 0
+    ) {
       if (isComplete(overtakeResult.projectedAverage)) {
         return overtakeResult.projectedAverage - 1;
       }

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -207,10 +207,10 @@ export function resultsForView(results, format, forecastView) {
 /**
  * Calculates the time required for input result to overatake
  * overtakeResult, based on the input format.
- * 
+ *
  * Assumes projectedAverage is already computed for both result
  * and overtakeResult
- * 
+ *
  * Handles incomplete and skipped values for overtakeResult
  */
 export function timeNeededToOvertake(result, format, overtakeResult) {

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -196,13 +196,11 @@ function timeNeededToOvertake(result, format, overtakeResult) {
   if (attemptResults.length === 2 && format.numberOfAttempts === 5) {
     // Projection will change from a mean to a median after a time is added
     if (
-      isComplete(resultWorst) &&
       compareAttemptResults(resultWorst, overtakeResult.projectedAverage) < 0
     ) {
       return DNF_VALUE;
     }
     if (
-      isComplete(result.best) &&
       compareAttemptResults(result.best, overtakeResult.projectedAverage) < 0
     ) {
       if (isComplete(overtakeResult.projectedAverage)) {
@@ -210,11 +208,6 @@ function timeNeededToOvertake(result, format, overtakeResult) {
       }
       return SUCCESS_VALUE;
     }
-    return NA_VALUE;
-  }
-
-  if (!isComplete(result.projectedAverage)) {
-    // DNF averages cannot overtake
     return NA_VALUE;
   }
 
@@ -228,6 +221,11 @@ function timeNeededToOvertake(result, format, overtakeResult) {
       return DNF_VALUE;
     }
     return SUCCESS_VALUE;
+  }
+
+  if (!isComplete(result.projectedAverage)) {
+    // DNF averages cannot overtake
+    return NA_VALUE;
   }
 
   const nextCountingSolves = result.attempts.length + (isMean ? 1 : -1);

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -1,16 +1,18 @@
 import { orderBy } from "./utils";
 import {
   compareAttemptResults,
+  formatAttemptResult,
   projectedAverage,
   padSkipped,
   toMonotonic,
   isSkipped,
   isComplete,
   SKIPPED_VALUE,
-  SUCCESS_VALUE,
-  NA_VALUE,
   DNF_VALUE,
 } from "./attempt-result";
+
+const NA_VALUE = -3;
+const SUCCESS_VALUE = -4;
 
 /**
  * Returns a list of objects corresponding to result statistics - best and average.
@@ -78,6 +80,12 @@ export function forecastViewSupported(round) {
     // condition and clinching logic on the client.
     round.advancementCondition === null
   );
+}
+
+export function formatAttemptResultForN(attemptResult, eventId) {
+  if (attemptResult === NA_VALUE) return "N/A";
+  if (attemptResult === SUCCESS_VALUE) return "SUCCESS";
+  return formatAttemptResult(attemptResult, eventId);
 }
 
 function sum(values) {

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -23,28 +23,27 @@ export function orderedResultStats(eventId, format, forecastView = null) {
     return [{ name: "Best", field: "best", recordTagField: "singleRecordTag" }];
   }
 
-  var stats = stats = [
+  var stats = (stats = [
     { name: "Best", field: "best", recordTagField: "singleRecordTag" },
     {
       name: numberOfAttempts === 3 ? "Mean" : "Average",
       field: "average",
       recordTagField: "averageRecordTag",
     },
-  ];
+  ]);
   stats = sortBy === "best" ? stats : stats.reverse();
   if (forecastView) {
     stats.push({
       name: "For 1st",
       field: "forFirst",
-    })
+    });
     stats.push({
       name: "For 3rd",
       field: "forThird",
-    })
+    });
   }
   return stats;
 }
-
 
 /**
  * Checks if an average should be calculated in case of the given event and format.
@@ -72,11 +71,11 @@ export function forecastViewSupported(round) {
     // Only relevant for rounds sorted by average
     round.format.sortBy != "best" &&
     // Fewest moves is currently not supported
-    round.competitionEvent.event.id != "333fm" // &&
+    round.competitionEvent.event.id != "333fm" &&
     // Currently only final rounds are supported. It is the most likely
     // use case and this way we don't need to replicate advancement
     // condition and clinching logic on the client.
-    // round.advancementCondition === null
+    round.advancementCondition === null
   );
 }
 
@@ -127,7 +126,7 @@ export function resultsForView(results, format, forecastView) {
 
     if (
       toMonotonic(currentResult.projectedAverage) ===
-      toMonotonic(prevResult.projectedAverage) &&
+        toMonotonic(prevResult.projectedAverage) &&
       toMonotonic(currentResult.best) === toMonotonic(prevResult.best)
     ) {
       // Rankings tie
@@ -154,8 +153,10 @@ export function resultsForView(results, format, forecastView) {
     prevResult = currentResult;
   }
 
-  const secondComplete = resultsForView.length > 1 && isComplete(resultsForView[1].projectedAverage);
-  const fourthComplete = resultsForView.length > 3 && isComplete(resultsForView[3].projectedAverage);
+  const secondComplete =
+    resultsForView.length > 1 && isComplete(resultsForView[1].projectedAverage);
+  const fourthComplete =
+    resultsForView.length > 3 && isComplete(resultsForView[3].projectedAverage);
   if (secondComplete) {
     for (let i = 0; i < resultsForView.length; i++) {
       var result = resultsForView[i];
@@ -164,10 +165,20 @@ export function resultsForView(results, format, forecastView) {
       }
       if (isSkipped(result.average)) {
         var firstIndex = i == 0 ? 1 : 0;
-        result.forFirst = timeNeededToOvertake(result, format, resultsForView[firstIndex].projectedAverage, resultsForView[firstIndex].best);
+        result.forFirst = timeNeededToOvertake(
+          result,
+          format,
+          resultsForView[firstIndex].projectedAverage,
+          resultsForView[firstIndex].best
+        );
         if (fourthComplete) {
           var thirdIndex = i < 3 ? 3 : 2;
-          result.forThird = timeNeededToOvertake(result, format, resultsForView[thirdIndex].projectedAverage, resultsForView[thirdIndex].best);
+          result.forThird = timeNeededToOvertake(
+            result,
+            format,
+            resultsForView[thirdIndex].projectedAverage,
+            resultsForView[thirdIndex].best
+          );
         }
       }
     }
@@ -176,14 +187,18 @@ export function resultsForView(results, format, forecastView) {
   return resultsForView;
 }
 
-export function timeNeededToOvertake(result, format, overtakeAverage, overtakeBest) {
+export function timeNeededToOvertake(
+  result,
+  format,
+  overtakeAverage,
+  overtakeBest
+) {
   var attemptResults = result.attempts.map((attempt) => attempt.result);
   if (attemptResults.length === 2 && format.numberOfAttempts === 5) {
     // Projection will change from a mean to a median after a time is added
     if (result.best < overtakeAverage) {
       return overtakeAverage - 1;
-    }
-    else {
+    } else {
       return NA_VALUE;
     }
   }
@@ -199,7 +214,8 @@ export function timeNeededToOvertake(result, format, overtakeAverage, overtakeBe
   const roundingBuffer = nextCountingSolves === 3 ? 1 : 0;
   var countingSum = sum(attemptResults);
   if (!isMean) {
-    countingSum = countingSum - Math.min(...attemptResults) - Math.max(...attemptResults);
+    countingSum =
+      countingSum - Math.min(...attemptResults) - Math.max(...attemptResults);
   }
 
   var needed = totalNeeded - countingSum + roundingBuffer;

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -95,6 +95,7 @@ export function resultsForView(results, format, forecastView) {
     return {
       ...result,
       projectedAverage: resultProjectedAverage(result, format),
+      // Don't set this for all results here - set lower
       countingSum: countingSum(result.attempts.map((attempt) => attempt.result), format),
       forFirst: SKIPPED_VALUE,
       forThird: SKIPPED_VALUE,
@@ -155,17 +156,31 @@ export function resultsForView(results, format, forecastView) {
   }
 
   const firstComplete = isComplete(resultsForView[0].projectedAverage);
-  const thirdComplete = isComplete(resultsForView[2].projectedAverage);
+  const secondComplete = resultsForView.length > 1 && isComplete(resultsForView[1].projectedAverage);
+  const thirdComplete = resultsForView.length > 2 && isComplete(resultsForView[2].projectedAverage);
+  const fourthComplete = resultsForView.length > 3 && isComplete(resultsForView[3].projectedAverage);
   if (firstComplete) {
-    for (let i = 1; i < resultsForView.length; i++) {
+    for (let i = 0; i < resultsForView.length; i++) {
       var result = resultsForView[i];
       if (isSkipped(result.projectedAverage)) {
         break;
       }
       if (isSkipped(result.average)) {
-        result.forFirst = timeNeededToOvertake(result, format, resultsForView[0].projectedAverage, resultsForView[0].best);
-        if (thirdComplete && i > 2) {
-          result.forThird = timeNeededToOvertake(result, format, resultsForView[2].projectedAverage, resultsForView[2].best);
+        if (i == 0) {
+          if (secondComplete) {
+            result.forFirst = timeNeededToOvertake(result, format, resultsForView[1].projectedAverage, resultsForView[1].best);
+          }
+        } else {
+          result.forFirst = timeNeededToOvertake(result, format, resultsForView[0].projectedAverage, resultsForView[0].best);
+        }
+        if (thirdComplete) {
+          if (i < 3) {
+            if (fourthComplete) {
+              result.forThird = timeNeededToOvertake(result, format, resultsForView[3].projectedAverage, resultsForView[3].best);
+            }
+          } else {
+            result.forThird = timeNeededToOvertake(result, format, resultsForView[2].projectedAverage, resultsForView[2].best);
+          }
         }
       }
     }

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -211,6 +211,7 @@ export function timeNeededToOvertake(
   const isMean = format.numberOfAttempts === 3 || result.attempts.length < 2;
   const nextCountingSolves = result.attempts.length + (isMean ? 1 : -1);
   const totalNeeded = overtakeAverage * nextCountingSolves;
+  // For a mean of 3, .01 can be added to achieve the same rounded result
   const roundingBuffer = nextCountingSolves === 3 ? 1 : 0;
   var countingSum = sum(attemptResults);
   if (!isMean) {
@@ -221,6 +222,7 @@ export function timeNeededToOvertake(
   var needed = totalNeeded - countingSum + roundingBuffer;
 
   const newBest = Math.min(needed, result.best);
+  // With the current "needed" value, the averages are tied.
   // If best is not better, adjust needed to overtake
   if (newBest >= overtakeBest) {
     // Win by decreasing average by .01 or by overtaking on single

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -257,6 +257,7 @@ describe("timeNeededToOvertake", () => {
   it("handles projected average turning from a mean to an average", () => {
     const format = { numberOfAttempts: 5 };
     let result = { attempts: [{ result: 99 }, { result: 100 }], best: 99 };
+
     // Worst possible average beats overtake average
     expect(
       timeNeededToOvertake(result, format, { best: 10, projectedAverage: 101 })
@@ -265,7 +266,9 @@ describe("timeNeededToOvertake", () => {
     expect(
       timeNeededToOvertake(result, format, { best: 100, projectedAverage: 100 })
     ).toEqual(-1);
+
     result = { attempts: [{ result: 100 }, { result: -1 }], best: 100 };
+
     // Best possible average beats overtake average, loses on best
     expect(
       timeNeededToOvertake(result, format, { best: 100, projectedAverage: 110 })
@@ -286,7 +289,9 @@ describe("timeNeededToOvertake", () => {
     expect(
       timeNeededToOvertake(result, format, { best: 50, projectedAverage: 50 })
     ).toEqual(-3);
+
     result = { attempts: [{ result: -1 }, { result: -1 }], best: -1 };
+
     // Best possible average ties overtake average, overtake average incomplete
     expect(
       timeNeededToOvertake(result, format, { best: -1, projectedAverage: -1 })
@@ -296,6 +301,7 @@ describe("timeNeededToOvertake", () => {
   it("handles incomplete overtake results", () => {
     let overtakeResult = { best: 50, projectedAverage: -1 };
     const format = { numberOfAttempts: 5 };
+
     // Result wins on best
     expect(
       timeNeededToOvertake(
@@ -350,7 +356,9 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(-4);
+
     overtakeResult = { best: -1, projectedAverage: -1 };
+
     // Both projected averages and bests incomplete, win on best
     expect(
       timeNeededToOvertake(
@@ -368,6 +376,7 @@ describe("timeNeededToOvertake", () => {
   it("handles incomplete results", () => {
     const overtakeResult = { best: 50, projectedAverage: 50 };
     const format = { numberOfAttempts: 3 };
+
     expect(
       timeNeededToOvertake(
         {
@@ -384,6 +393,7 @@ describe("timeNeededToOvertake", () => {
   it("handles overtake for mean", () => {
     let overtakeResult = { best: 100, projectedAverage: 100 };
     let format = { numberOfAttempts: 3 };
+
     // Tie average, win on best
     expect(
       timeNeededToOvertake(
@@ -408,7 +418,9 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(81);
+
     overtakeResult = { best: 50, projectedAverage: 100 };
+
     // Win on average, lose on best
     expect(
       timeNeededToOvertake(
@@ -435,6 +447,7 @@ describe("timeNeededToOvertake", () => {
     ).toEqual(78);
 
     overtakeResult = { best: 80, projectedAverage: 100 };
+
     // Tie on average, win on best (incremented by 1)
     expect(
       timeNeededToOvertake(
@@ -450,6 +463,7 @@ describe("timeNeededToOvertake", () => {
 
     format = { numberOfAttempts: 5 };
     overtakeResult = { best: 100, projectedAverage: 100 };
+
     // Validate 5 attemps with 1 result is treated as a mean
     expect(
       timeNeededToOvertake(
@@ -467,6 +481,7 @@ describe("timeNeededToOvertake", () => {
   it("handles overtake for average", () => {
     let overtakeResult = { best: 50, projectedAverage: 100 };
     const format = { numberOfAttempts: 5 };
+
     // Tie average, win on best (including worst solve DNF)
     expect(
       timeNeededToOvertake(

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -1,4 +1,45 @@
-import { resultsForView } from "../result";
+import { attemptResultsWarning, projectedAverage } from "../attempt-result";
+import {
+  formatAttemptResultForN,
+  resultsForView,
+  orderedResultStats,
+  timeNeededToOvertake,
+} from "../result";
+
+describe("orderedResultStats", () => {
+  it("returns 'forFirst' and 'forThird' when forecase view is enabled", () => {
+    const eventId = "333";
+    const format = { numberOfAttempts: 5, sortBy: "average" };
+    const bestStat = {
+      name: "Best",
+      field: "best",
+      recordTagField: "singleRecordTag",
+    };
+    const averageStat = {
+      name: "Average",
+      field: "average",
+      recordTagField: "averageRecordTag",
+    };
+    expect(orderedResultStats(eventId, format, false)).toMatchObject([
+      averageStat,
+      bestStat,
+    ]);
+    expect(orderedResultStats(eventId, format, true)).toMatchObject([
+      averageStat,
+      bestStat,
+      { name: "For 1st", field: "forFirst" },
+      { name: "For 3rd", field: "forThird" },
+    ]);
+  });
+});
+
+describe("formatAttemptResultForN", () => {
+  it("Handles NA_VALUE and SUCCESS_VALUE", () => {
+    expect(formatAttemptResultForN(-3, "333")).toEqual("N/A");
+    expect(formatAttemptResultForN(-4, "333")).toEqual("SUCCESS");
+    expect(formatAttemptResultForN(-1, "333")).toEqual("DNF");
+  });
+});
 
 describe("viewResults", () => {
   it("returns unaltered results if forecastView is not enabled", () => {
@@ -147,5 +188,300 @@ describe("viewResults", () => {
       advancing: false,
       advancingQuestionable: false,
     });
+  });
+
+  it("sets forFirst/forThird based on times needed to achieve 1st/3rd", () => {
+    const format = { numberOfAttempts: 3 };
+    const results = [
+      {
+        ranking: 1,
+        attempts: [{ result: 100 }],
+        best: 100,
+        average: 0,
+      },
+      {
+        ranking: 2,
+        attempts: [{ result: 101 }],
+        best: 101,
+        average: 0,
+      },
+      {
+        ranking: 3,
+        attempts: [{ result: 102 }],
+        best: 102,
+        average: 0,
+      },
+      {
+        ranking: 4,
+        attempts: [{ result: 103 }],
+        best: 103,
+        average: 0,
+      },
+      {
+        ranking: 5,
+        attempts: [{ result: 104 }, { result: 104 }, { result: 104 }],
+        best: 104,
+        average: 104,
+      },
+    ];
+    const viewResults = resultsForView(results, format, true);
+    expect(viewResults[0]).toMatchObject({
+      forFirst: 102,
+      forThird: 106,
+    });
+    expect(viewResults[1]).toMatchObject({
+      forFirst: 99,
+      forThird: 105,
+    });
+    expect(viewResults[2]).toMatchObject({
+      forFirst: 98,
+      forThird: 104,
+    });
+    expect(viewResults[3]).toMatchObject({
+      forFirst: 97,
+      forThird: 101,
+    });
+    expect(viewResults[4]).toMatchObject({
+      forFirst: 0,
+      forThird: 0,
+    });
+  });
+});
+
+describe("timeNeededToOvertake", () => {
+  it("returns DNF if overtake result is skipped", () => {
+    expect(timeNeededToOvertake(null, null, { projectedAverage: 0 })).toEqual(
+      -1
+    );
+  });
+
+  it("handles results turning from a mean to an average", () => {
+    const format = { numberOfAttempts: 5 };
+    let result = { attempts: [{ result: 99 }, { result: 100 }], best: 99 };
+    expect(
+      timeNeededToOvertake(result, format, { best: 10, projectedAverage: 101 })
+    ).toEqual(-1);
+    expect(
+      timeNeededToOvertake(result, format, { best: 100, projectedAverage: 100 })
+    ).toEqual(-1);
+    result = { attempts: [{ result: 100 }, { result: -1 }], best: 100 };
+    expect(
+      timeNeededToOvertake(result, format, { best: 100, projectedAverage: 110 })
+    ).toEqual(109);
+    expect(
+      timeNeededToOvertake(result, format, { best: 101, projectedAverage: 110 })
+    ).toEqual(110);
+    expect(
+      timeNeededToOvertake(result, format, { best: 50, projectedAverage: -1 })
+    ).toEqual(-4);
+    expect(
+      timeNeededToOvertake(result, format, { best: 50, projectedAverage: 100 })
+    ).toEqual(49);
+    expect(
+      timeNeededToOvertake(result, format, { best: 50, projectedAverage: 50 })
+    ).toEqual(-3);
+  });
+
+  it("handles incomplete overtake results", () => {
+    const overtakeResult = { best: 50, projectedAverage: -1 };
+    const format = { numberOfAttempts: 5 };
+    expect(
+      timeNeededToOvertake(
+        { best: 49, projectedAverage: 49, attempts: [{ result: 49 }] },
+        format,
+        overtakeResult
+      )
+    ).toEqual(-1);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 100,
+          projectedAverage: 100,
+          attempts: [
+            { result: 100 },
+            { result: 100 },
+            { result: 100 },
+            { result: 100 },
+          ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(-1);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 100,
+          projectedAverage: 100,
+          attempts: [{ result: 100 }],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(-4);
+  });
+
+  it("handles incomplete results", () => {
+    const overtakeResult = { best: 50, projectedAverage: 50 };
+    const format = { numberOfAttempts: 3 };
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 50,
+          projectedAverage: -1,
+          attempts: [{ result: 50 }, { result: -1 }],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(-3);
+  });
+
+  it("handles overtake for mean", () => {
+    let overtakeResult = { best: 100, projectedAverage: 100 };
+    let format = { numberOfAttempts: 3 };
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 110,
+          projectedAverage: 110,
+          attempts: [{ result: 110 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(90);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 110,
+          projectedAverage: 110,
+          attempts: [{ result: 110 }, { result: 110 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(81);
+    overtakeResult = { best: 50, projectedAverage: 100 };
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 110,
+          projectedAverage: 110,
+          attempts: [{ result: 110 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(88);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 110,
+          projectedAverage: 110,
+          attempts: [{ result: 110 }, { result: 110 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(78);
+
+    overtakeResult = { best: 80, projectedAverage: 100 };
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 110,
+          projectedAverage: 110,
+          attempts: [{ result: 110 }, { result: 110 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(79);
+
+    format = { numberOfAttempts: 5 };
+    overtakeResult = { best: 100, projectedAverage: 100 };
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 110,
+          projectedAverage: 110,
+          attempts: [{ result: 110 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(90);
+  });
+
+  it("handles overtake for average", () => {
+    let overtakeResult = { best: 50, projectedAverage: 100 };
+    const format = { numberOfAttempts: 5 };
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 10,
+          projectedAverage: 110,
+          attempts: [{ result: 10 }, { result: 110 }, { result: 200 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(90);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 50,
+          projectedAverage: 110,
+          attempts: [{ result: 50 }, { result: 110 }, { result: 200 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(88);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 10,
+          projectedAverage: 110,
+          attempts: [{ result: 10 }, { result: 110 }, { result: 110 }, { result: 200 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(81);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 50,
+          projectedAverage: 110,
+          attempts: [{ result: 50 }, { result: 110 }, { result: 110 }, { result: 200 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(78);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 110,
+          projectedAverage: 110,
+          attempts: [{ result: 110 }, { result: 110 }, { result: 110 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(-3);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 90,
+          projectedAverage: 90,
+          attempts: [{ result: 90 }, { result: 90 }, { result: 90 } ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(-1);
   });
 });

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -1,4 +1,3 @@
-import { projectedAverage } from "../attempt-result";
 import {
   formatAttemptResultForN,
   resultsForView,

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -1,5 +1,5 @@
 import {
-  formatAttemptResultForN,
+  formatAttemptResultForView,
   resultsForView,
   orderedResultStats,
   timeNeededToOvertake,
@@ -32,11 +32,11 @@ describe("orderedResultStats", () => {
   });
 });
 
-describe("formatAttemptResultForN", () => {
+describe("formatAttemptResultForView", () => {
   it("Handles NA_VALUE and SUCCESS_VALUE", () => {
-    expect(formatAttemptResultForN(-3, "333")).toEqual("N/A");
-    expect(formatAttemptResultForN(-4, "333")).toEqual("SUCCESS");
-    expect(formatAttemptResultForN(-1, "333")).toEqual("DNF");
+    expect(formatAttemptResultForView(-3, "333")).toEqual("N/A");
+    expect(formatAttemptResultForView(-4, "333")).toEqual("SUCCESS");
+    expect(formatAttemptResultForView(-1, "333")).toEqual("DNF");
   });
 });
 

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -1,3 +1,4 @@
+import { projectedAverage } from "../attempt-result";
 import {
   formatAttemptResultForN,
   resultsForView,
@@ -279,10 +280,14 @@ describe("timeNeededToOvertake", () => {
     expect(
       timeNeededToOvertake(result, format, { best: 50, projectedAverage: 50 })
     ).toEqual(-3);
+    result = { attempts: [{ result: -1 }, { result: -1 }], best: -1 };
+    expect(
+      timeNeededToOvertake(result, format, { best: -1, projectedAverage: -1 })
+    ).toEqual(-4);
   });
 
   it("handles incomplete overtake results", () => {
-    const overtakeResult = { best: 50, projectedAverage: -1 };
+    let overtakeResult = { best: 50, projectedAverage: -1 };
     const format = { numberOfAttempts: 5 };
     expect(
       timeNeededToOvertake(
@@ -311,8 +316,36 @@ describe("timeNeededToOvertake", () => {
       timeNeededToOvertake(
         {
           best: 100,
+          projectedAverage: -1,
+          attempts: [
+            { result: 100 },
+            { result: 100 },
+            { result: -1 },
+            { result: -1 },
+          ],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(49);
+    expect(
+      timeNeededToOvertake(
+        {
+          best: 100,
           projectedAverage: 100,
           attempts: [{ result: 100 }],
+        },
+        format,
+        overtakeResult
+      )
+    ).toEqual(-4);
+    overtakeResult = { best: -1, projectedAverage: -1 };
+    expect(
+      timeNeededToOvertake(
+        {
+          best: -1,
+          projectedAverage: -1,
+          attempts: [{ result: -1 }],
         },
         format,
         overtakeResult
@@ -421,7 +454,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 10,
           projectedAverage: 110,
-          attempts: [{ result: 10 }, { result: 110 }, { result: 200 }],
+          attempts: [{ result: 10 }, { result: 110 }, { result: -1 }],
         },
         format,
         overtakeResult
@@ -432,7 +465,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 50,
           projectedAverage: 110,
-          attempts: [{ result: 50 }, { result: 110 }, { result: 200 }],
+          attempts: [{ result: 50 }, { result: 110 }, { result: -1 }],
         },
         format,
         overtakeResult

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -345,7 +345,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 110,
           projectedAverage: 110,
-          attempts: [{ result: 110 } ],
+          attempts: [{ result: 110 }],
         },
         format,
         overtakeResult
@@ -356,7 +356,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 110,
           projectedAverage: 110,
-          attempts: [{ result: 110 }, { result: 110 } ],
+          attempts: [{ result: 110 }, { result: 110 }],
         },
         format,
         overtakeResult
@@ -368,7 +368,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 110,
           projectedAverage: 110,
-          attempts: [{ result: 110 } ],
+          attempts: [{ result: 110 }],
         },
         format,
         overtakeResult
@@ -379,7 +379,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 110,
           projectedAverage: 110,
-          attempts: [{ result: 110 }, { result: 110 } ],
+          attempts: [{ result: 110 }, { result: 110 }],
         },
         format,
         overtakeResult
@@ -392,7 +392,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 110,
           projectedAverage: 110,
-          attempts: [{ result: 110 }, { result: 110 } ],
+          attempts: [{ result: 110 }, { result: 110 }],
         },
         format,
         overtakeResult
@@ -406,7 +406,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 110,
           projectedAverage: 110,
-          attempts: [{ result: 110 } ],
+          attempts: [{ result: 110 }],
         },
         format,
         overtakeResult
@@ -422,7 +422,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 10,
           projectedAverage: 110,
-          attempts: [{ result: 10 }, { result: 110 }, { result: 200 } ],
+          attempts: [{ result: 10 }, { result: 110 }, { result: 200 }],
         },
         format,
         overtakeResult
@@ -433,7 +433,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 50,
           projectedAverage: 110,
-          attempts: [{ result: 50 }, { result: 110 }, { result: 200 } ],
+          attempts: [{ result: 50 }, { result: 110 }, { result: 200 }],
         },
         format,
         overtakeResult
@@ -444,7 +444,12 @@ describe("timeNeededToOvertake", () => {
         {
           best: 10,
           projectedAverage: 110,
-          attempts: [{ result: 10 }, { result: 110 }, { result: 110 }, { result: 200 } ],
+          attempts: [
+            { result: 10 },
+            { result: 110 },
+            { result: 110 },
+            { result: 200 },
+          ],
         },
         format,
         overtakeResult
@@ -455,7 +460,12 @@ describe("timeNeededToOvertake", () => {
         {
           best: 50,
           projectedAverage: 110,
-          attempts: [{ result: 50 }, { result: 110 }, { result: 110 }, { result: 200 } ],
+          attempts: [
+            { result: 50 },
+            { result: 110 },
+            { result: 110 },
+            { result: 200 },
+          ],
         },
         format,
         overtakeResult
@@ -466,7 +476,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 110,
           projectedAverage: 110,
-          attempts: [{ result: 110 }, { result: 110 }, { result: 110 } ],
+          attempts: [{ result: 110 }, { result: 110 }, { result: 110 }],
         },
         format,
         overtakeResult
@@ -477,7 +487,7 @@ describe("timeNeededToOvertake", () => {
         {
           best: 90,
           projectedAverage: 90,
-          attempts: [{ result: 90 }, { result: 90 }, { result: 90 } ],
+          attempts: [{ result: 90 }, { result: 90 }, { result: 90 }],
         },
         format,
         overtakeResult

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -1,4 +1,3 @@
-import { attemptResultsWarning, projectedAverage } from "../attempt-result";
 import {
   formatAttemptResultForN,
   resultsForView,

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -254,32 +254,40 @@ describe("timeNeededToOvertake", () => {
     );
   });
 
-  it("handles results turning from a mean to an average", () => {
+  it("handles projected average turning from a mean to an average", () => {
     const format = { numberOfAttempts: 5 };
     let result = { attempts: [{ result: 99 }, { result: 100 }], best: 99 };
+    // Worst possible average beats overtake average
     expect(
       timeNeededToOvertake(result, format, { best: 10, projectedAverage: 101 })
     ).toEqual(-1);
+    // Worst possible average ties overtake average, wins on best
     expect(
       timeNeededToOvertake(result, format, { best: 100, projectedAverage: 100 })
     ).toEqual(-1);
     result = { attempts: [{ result: 100 }, { result: -1 }], best: 100 };
+    // Best possible average beats overtake average, loses on best
     expect(
       timeNeededToOvertake(result, format, { best: 100, projectedAverage: 110 })
     ).toEqual(109);
+    // Best possible average beats overtake average, wins on best
     expect(
       timeNeededToOvertake(result, format, { best: 101, projectedAverage: 110 })
     ).toEqual(110);
+    // Best possible average beats overtake average, overtake average incomplete
     expect(
       timeNeededToOvertake(result, format, { best: 50, projectedAverage: -1 })
     ).toEqual(-4);
+    // Best possible average ties overtake average
     expect(
       timeNeededToOvertake(result, format, { best: 50, projectedAverage: 100 })
     ).toEqual(49);
+    // Best possible average loses to overtake average
     expect(
       timeNeededToOvertake(result, format, { best: 50, projectedAverage: 50 })
     ).toEqual(-3);
     result = { attempts: [{ result: -1 }, { result: -1 }], best: -1 };
+    // Best possible average ties overtake average, overtake average incomplete
     expect(
       timeNeededToOvertake(result, format, { best: -1, projectedAverage: -1 })
     ).toEqual(-4);
@@ -288,6 +296,7 @@ describe("timeNeededToOvertake", () => {
   it("handles incomplete overtake results", () => {
     let overtakeResult = { best: 50, projectedAverage: -1 };
     const format = { numberOfAttempts: 5 };
+    // Result wins on best
     expect(
       timeNeededToOvertake(
         { best: 49, projectedAverage: 49, attempts: [{ result: 49 }] },
@@ -295,6 +304,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(-1);
+    // Worst possible average is complete
     expect(
       timeNeededToOvertake(
         {
@@ -311,6 +321,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(-1);
+    // Both projected averages incomplete, win on best
     expect(
       timeNeededToOvertake(
         {
@@ -327,6 +338,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(49);
+    // Any success will beat an incomplete result
     expect(
       timeNeededToOvertake(
         {
@@ -339,6 +351,7 @@ describe("timeNeededToOvertake", () => {
       )
     ).toEqual(-4);
     overtakeResult = { best: -1, projectedAverage: -1 };
+    // Both projected averages and bests incomplete, win on best
     expect(
       timeNeededToOvertake(
         {
@@ -371,6 +384,7 @@ describe("timeNeededToOvertake", () => {
   it("handles overtake for mean", () => {
     let overtakeResult = { best: 100, projectedAverage: 100 };
     let format = { numberOfAttempts: 3 };
+    // Tie average, win on best
     expect(
       timeNeededToOvertake(
         {
@@ -382,6 +396,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(90);
+    // Tie average, win on best (with rounding buffer)
     expect(
       timeNeededToOvertake(
         {
@@ -394,6 +409,7 @@ describe("timeNeededToOvertake", () => {
       )
     ).toEqual(81);
     overtakeResult = { best: 50, projectedAverage: 100 };
+    // Win on average, lose on best
     expect(
       timeNeededToOvertake(
         {
@@ -405,6 +421,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(88);
+    // Win on average, lose on best (with rounding buffer)
     expect(
       timeNeededToOvertake(
         {
@@ -418,6 +435,7 @@ describe("timeNeededToOvertake", () => {
     ).toEqual(78);
 
     overtakeResult = { best: 80, projectedAverage: 100 };
+    // Tie on average, win on best (incremented by 1)
     expect(
       timeNeededToOvertake(
         {
@@ -432,6 +450,7 @@ describe("timeNeededToOvertake", () => {
 
     format = { numberOfAttempts: 5 };
     overtakeResult = { best: 100, projectedAverage: 100 };
+    // Validate 5 attemps with 1 result is treated as a mean
     expect(
       timeNeededToOvertake(
         {
@@ -448,6 +467,7 @@ describe("timeNeededToOvertake", () => {
   it("handles overtake for average", () => {
     let overtakeResult = { best: 50, projectedAverage: 100 };
     const format = { numberOfAttempts: 5 };
+    // Tie average, win on best (including worst solve DNF)
     expect(
       timeNeededToOvertake(
         {
@@ -459,6 +479,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(90);
+    // Win average, tie on best (including worst solve DNF)
     expect(
       timeNeededToOvertake(
         {
@@ -470,6 +491,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(88);
+    // Tie average, win on best (with rounding buffer)
     expect(
       timeNeededToOvertake(
         {
@@ -486,6 +508,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(81);
+    // Win average, tie on best (with rounding buffer)
     expect(
       timeNeededToOvertake(
         {
@@ -502,6 +525,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(78);
+    // Best possible average is slower than overtake projected average
     expect(
       timeNeededToOvertake(
         {
@@ -513,6 +537,7 @@ describe("timeNeededToOvertake", () => {
         overtakeResult
       )
     ).toEqual(-3);
+    // Worst possible average is faster than overtake projected average
     expect(
       timeNeededToOvertake(
         {

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -17,6 +17,6 @@ export default defineConfig({
     },
     // Uncomment when running using Docker on Windows.
     // See https://github.com/vitejs/vite/issues/1153#issuecomment-785467271
-    watch: { usePolling: true },
+    // watch: { usePolling: true },
   },
 });

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -17,6 +17,6 @@ export default defineConfig({
     },
     // Uncomment when running using Docker on Windows.
     // See https://github.com/vitejs/vite/issues/1153#issuecomment-785467271
-    // watch: { usePolling: true },
+    watch: { usePolling: true },
   },
 });


### PR DESCRIPTION
Add 2 new statistics columns, "For First" and "For Third" to forecast view.

Columns show the time needed for a competitor to overtake 1st/3rd on their next solve.

All calculations are done using projected averages.