### PR TITLE
Update forecast view to support 333fm

### DIFF
--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -88,7 +88,7 @@ function ResultsProjector({
   const [topResultIndex, setTopResultIndex] = useState(0);
 
   const stats = orderedResultStats(eventId, format, forecastView);
-  const nonemptyResults = resultsForView(results, format, forecastView).filter(
+  const nonemptyResults = resultsForView(results, eventId, format, forecastView).filter(
     (result) => result.attempts.length > 0
   );
 

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -88,9 +88,12 @@ function ResultsProjector({
   const [topResultIndex, setTopResultIndex] = useState(0);
 
   const stats = orderedResultStats(eventId, format, forecastView);
-  const nonemptyResults = resultsForView(results, eventId, format, forecastView).filter(
-    (result) => result.attempts.length > 0
-  );
+  const nonemptyResults = resultsForView(
+    results,
+    eventId,
+    format,
+    forecastView
+  ).filter((result) => result.attempts.length > 0);
 
   useEffect(() => {
     if (status === STATUS.SHOWN) {

--- a/client/src/components/RoundResults/RoundResultsTable.jsx
+++ b/client/src/components/RoundResults/RoundResultsTable.jsx
@@ -64,7 +64,7 @@ const RoundResultsTable = memo(
 
     const stats = orderedResultStats(eventId, format, forecastView);
 
-    const viewResults = resultsForView(results, format, forecastView);
+    const viewResults = resultsForView(results, eventId, format, forecastView);
     return (
       <Paper>
         <Table size="small">

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -152,8 +152,14 @@ function mean(values) {
  * When all result attempts are present, the return value is the same
  * as the usual average.
  */
-export function projectedAverage(attemptResults, format) {
+export function projectedAverage(attemptResults, eventId, format) {
   if (attemptResults.length === 0) return SKIPPED_VALUE;
+
+  if (eventId === "333fm") {
+    if (!attemptResults.every(isComplete)) return DNF_VALUE;
+    const scaled = attemptResults.map((attemptResult) => attemptResult * 100);
+    return mean(scaled);
+  }
 
   if (format.numberOfAttempts === 3) {
     return meanOfX(attemptResults);

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -170,7 +170,7 @@ export function resultsForView(results, eventId, format, forecastView) {
     prevResult = currentResult;
   }
 
-  if (resultsForView.length > 1) {
+  if (resultsForView.length > 1 && eventId != "333fm") {
     for (let i = 0; i < resultsForView.length; i++) {
       let result = resultsForView[i];
       if (result.attempts.length === 0) {

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -35,7 +35,7 @@ export function orderedResultStats(eventId, format, forecastView = false) {
     },
   ];
   stats = sortBy === "best" ? stats : stats.reverse();
-  if (forecastView) {
+  if (forecastView && eventId != "333fm") {
     stats.push({
       name: "For 1st",
       field: "forFirst",
@@ -73,8 +73,6 @@ export function forecastViewSupported(round) {
   return (
     // Only relevant for rounds sorted by average
     round.format.sortBy != "best" &&
-    // Fewest moves is currently not supported
-    round.competitionEvent.event.id != "333fm" &&
     // Currently only final rounds are supported. It is the most likely
     // use case and this way we don't need to replicate advancement
     // condition and clinching logic on the client.
@@ -107,13 +105,13 @@ function sum(values) {
  *  * `forThird` - time needed to overtake 3rd place
  *
  */
-export function resultsForView(results, format, forecastView) {
+export function resultsForView(results, eventId, format, forecastView) {
   if (results.length == 0 || !forecastView) return results;
 
   let resultsForView = results.map((result) => {
     return {
       ...result,
-      projectedAverage: resultProjectedAverage(result, format),
+      projectedAverage: resultProjectedAverage(result, eventId, format),
       forFirst: SKIPPED_VALUE,
       forThird: SKIPPED_VALUE,
     };
@@ -313,11 +311,11 @@ export function timeNeededToOvertake(result, format, overtakeResult) {
   return needed;
 }
 
-function resultProjectedAverage(result, format) {
+function resultProjectedAverage(result, eventId, format) {
   if (!isSkipped(result.average)) {
     return result.average;
   }
 
   const attemptResults = result.attempts.map((attempt) => attempt.result);
-  return projectedAverage(attemptResults, format);
+  return projectedAverage(attemptResults, eventId, format);
 }

--- a/client/src/lib/tests/attempt-result.test.js
+++ b/client/src/lib/tests/attempt-result.test.js
@@ -622,28 +622,37 @@ describe("incompleteMean", () => {
 });
 
 describe("projectedAverage", () => {
+  const event333 = "333";
   it("returns mean when format is mean of 3", () => {
     const format = { numberOfAttempts: 3 };
-    expect(projectedAverage([], format)).toEqual(0);
-    expect(projectedAverage([100], format)).toEqual(100);
-    expect(projectedAverage([100, 102], format)).toEqual(101);
-    expect(projectedAverage([100, 101, 102], format)).toEqual(101);
+    expect(projectedAverage([], event333, format)).toEqual(0);
+    expect(projectedAverage([100], event333, format)).toEqual(100);
+    expect(projectedAverage([100, 102], event333, format)).toEqual(101);
+    expect(projectedAverage([100, 101, 102], event333, format)).toEqual(101);
   });
 
   it("returns mean when format is average of 5 and there are less than 3 attempts", () => {
     const format = { numberOfAttempts: 5 };
-    expect(projectedAverage([100], format)).toEqual(100);
-    expect(projectedAverage([100, 102], format)).toEqual(101);
+    expect(projectedAverage([100], event333, format)).toEqual(100);
+    expect(projectedAverage([100, 102], event333, format)).toEqual(101);
   });
 
   it("returns median when format is average of 5 and there are 3 or 4 attempts", () => {
     const format = { numberOfAttempts: 5 };
-    expect(projectedAverage([100, 101, 102], format)).toEqual(101);
-    expect(projectedAverage([100, 101, 103, 104], format)).toEqual(102);
+    expect(projectedAverage([100, 101, 102], event333, format)).toEqual(101);
+    expect(projectedAverage([100, 101, 103, 104], event333, format)).toEqual(102);
   });
 
   it("returns average of 5 when format is average of 5 and there are 5 attempts", () => {
     const format = { numberOfAttempts: 5 };
-    expect(projectedAverage([100, 101, 102, 103, 200], format)).toEqual(102);
+    expect(projectedAverage([100, 101, 102, 103, 200], event333, format)).toEqual(102);
+  });
+
+  it("returns scaled mean when event is 333 fewest moves", () => {
+    const format = { numberOfAttempts: 5 };
+    const event333fm = "333fm"
+    expect(projectedAverage([20], event333fm, format)).toEqual(2000);
+    expect(projectedAverage([20, 21], event333fm, format)).toEqual(2050);
+    expect(projectedAverage([20, 20, 21], event333fm, format)).toEqual(2033);
   });
 });

--- a/client/src/lib/tests/attempt-result.test.js
+++ b/client/src/lib/tests/attempt-result.test.js
@@ -640,17 +640,21 @@ describe("projectedAverage", () => {
   it("returns median when format is average of 5 and there are 3 or 4 attempts", () => {
     const format = { numberOfAttempts: 5 };
     expect(projectedAverage([100, 101, 102], event333, format)).toEqual(101);
-    expect(projectedAverage([100, 101, 103, 104], event333, format)).toEqual(102);
+    expect(projectedAverage([100, 101, 103, 104], event333, format)).toEqual(
+      102
+    );
   });
 
   it("returns average of 5 when format is average of 5 and there are 5 attempts", () => {
     const format = { numberOfAttempts: 5 };
-    expect(projectedAverage([100, 101, 102, 103, 200], event333, format)).toEqual(102);
+    expect(
+      projectedAverage([100, 101, 102, 103, 200], event333, format)
+    ).toEqual(102);
   });
 
   it("returns scaled mean when event is 333 fewest moves", () => {
     const format = { numberOfAttempts: 5 };
-    const event333fm = "333fm"
+    const event333fm = "333fm";
     expect(projectedAverage([20], event333fm, format)).toEqual(2000);
     expect(projectedAverage([20, 21], event333fm, format)).toEqual(2050);
     expect(projectedAverage([20, 20, 21], event333fm, format)).toEqual(2033);

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -41,7 +41,6 @@ describe("formatAttemptResultForView", () => {
 });
 
 describe("viewResults", () => {
-  const event333 = "333;"
   it("returns unaltered results if forecastView is not enabled", () => {
     const results = [
       {
@@ -50,6 +49,7 @@ describe("viewResults", () => {
         attempts: [{ result: 1000 }, { result: 1000 }, { result: 1000 }],
       },
     ];
+    const event333 = "333";
     expect(resultsForView(results, event333, null, false)).toEqual(results);
   });
 
@@ -72,6 +72,7 @@ describe("viewResults", () => {
         average: 0,
       },
     ];
+    const event333 = "333";
 
     const viewResults = resultsForView(results, event333, format, true);
     expect(viewResults[0].projectedAverage).toEqual(1100);
@@ -132,6 +133,7 @@ describe("viewResults", () => {
         advancingQuestionable: false,
       },
     ];
+    const event333 = "333";
 
     const viewResults = resultsForView(results, event333, format, true);
     expect(viewResults[0]).toMatchObject({
@@ -252,6 +254,7 @@ describe("viewResults", () => {
         average: 104,
       },
     ];
+    const event333 = "333";
     const viewResults = resultsForView(results, event333, format, true);
     expect(viewResults[0]).toMatchObject({
       forFirst: 102,

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -41,6 +41,7 @@ describe("formatAttemptResultForView", () => {
 });
 
 describe("viewResults", () => {
+  const event333 = "333;"
   it("returns unaltered results if forecastView is not enabled", () => {
     const results = [
       {
@@ -49,7 +50,7 @@ describe("viewResults", () => {
         attempts: [{ result: 1000 }, { result: 1000 }, { result: 1000 }],
       },
     ];
-    expect(resultsForView(results, null, false)).toEqual(results);
+    expect(resultsForView(results, event333, null, false)).toEqual(results);
   });
 
   it("computes projected average on all results", () => {
@@ -72,7 +73,7 @@ describe("viewResults", () => {
       },
     ];
 
-    const viewResults = resultsForView(results, format, true);
+    const viewResults = resultsForView(results, event333, format, true);
     expect(viewResults[0].projectedAverage).toEqual(1100);
     expect(viewResults[1].projectedAverage).toEqual(1400);
     expect(viewResults[2].projectedAverage).toEqual(2100);
@@ -132,7 +133,7 @@ describe("viewResults", () => {
       },
     ];
 
-    const viewResults = resultsForView(results, format, true);
+    const viewResults = resultsForView(results, event333, format, true);
     expect(viewResults[0]).toMatchObject({
       ranking: 1,
       attempts: [{ result: 10 }, { result: 10 }, { result: 10 }],
@@ -189,6 +190,34 @@ describe("viewResults", () => {
     });
   });
 
+  it("deesn't set forFirst/forThird for fewest moves", () => {
+    const event333fm = "333fm";
+    const format = { numberOfAttempts: 3 };
+    const results = [
+      {
+        ranking: 1,
+        attempts: [{ result: 20 }],
+        best: 20,
+        average: 0,
+      },
+      {
+        ranking: 2,
+        attempts: [{ result: 20 }],
+        best: 20,
+        average: 0,
+      },
+    ];
+    const viewResults = resultsForView(results, event333fm, format, true);
+    expect(viewResults[0]).toMatchObject({
+      forFirst: 0,
+      forThird: 0,
+    });
+    expect(viewResults[1]).toMatchObject({
+      forFirst: 0,
+      forThird: 0,
+    });
+  });
+
   it("sets forFirst/forThird based on times needed to achieve 1st/3rd", () => {
     const format = { numberOfAttempts: 3 };
     const results = [
@@ -223,7 +252,7 @@ describe("viewResults", () => {
         average: 104,
       },
     ];
-    const viewResults = resultsForView(results, format, true);
+    const viewResults = resultsForView(results, event333, format, true);
     expect(viewResults[0]).toMatchObject({
       forFirst: 102,
       forThird: 106,


### PR DESCRIPTION
Add fewest moves support to forecast view. Just add support for ranking by projected average. "For First" and "For Third" are not as relevant since every solve is concurrent anyways. Also I don't feel like supporting that logic. I think the most helpful thing is to just rank on projected average.