### PR TITLE
Support forecast view for non final rounds with "ranking " advancement condition type

### DIFF
--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -83,14 +83,23 @@ function ResultsProjector({
   title,
   exitUrl,
   forecastView,
+  advancementCondition,
 }) {
   const [status, setStatus] = useState(STATUS.SHOWING);
   const [topResultIndex, setTopResultIndex] = useState(0);
 
-  const stats = orderedResultStats(eventId, format, forecastView);
-  const nonemptyResults = resultsForView(results, format, forecastView).filter(
-    (result) => result.attempts.length > 0
+  const stats = orderedResultStats(
+    eventId,
+    format,
+    forecastView,
+    advancementCondition
   );
+  const nonemptyResults = resultsForView(
+    results,
+    format,
+    forecastView,
+    advancementCondition
+  ).filter((result) => result.attempts.length > 0);
 
   useEffect(() => {
     if (status === STATUS.SHOWN) {

--- a/client/src/components/Round/Round.jsx
+++ b/client/src/components/Round/Round.jsx
@@ -144,6 +144,7 @@ function Round() {
                   title={`${round.competitionEvent.event.name} - ${round.name}`}
                   exitUrl={`/competitions/${competitionId}/rounds/${roundId}`}
                   forecastView={forecastView}
+                  advancementCondition={round.advancementCondition}
                 />
               }
             />
@@ -158,6 +159,7 @@ function Round() {
                   eventId={round.competitionEvent.event.id}
                   competitionId={competitionId}
                   forecastView={forecastView}
+                  advancementCondition={round.advancementCondition}
                 />
               }
             />

--- a/client/src/components/RoundResults/RoundResults.jsx
+++ b/client/src/components/RoundResults/RoundResults.jsx
@@ -11,6 +11,7 @@ function RoundResults({
   eventId,
   competitionId,
   forecastView,
+  advancementCondition
 }) {
   const smScreen = useMediaQuery((theme) => theme.breakpoints.up("sm"));
 
@@ -42,6 +43,7 @@ function RoundResults({
             competitionId={competitionId}
             onResultClick={handleResultClick}
             forecastView={forecastView}
+            advancementCondition={advancementCondition}
           />
         </Grid>
         {!showAll && (

--- a/client/src/components/RoundResults/RoundResults.jsx
+++ b/client/src/components/RoundResults/RoundResults.jsx
@@ -11,7 +11,7 @@ function RoundResults({
   eventId,
   competitionId,
   forecastView,
-  advancementCondition
+  advancementCondition,
 }) {
   const smScreen = useMediaQuery((theme) => theme.breakpoints.up("sm"));
 

--- a/client/src/components/RoundResults/RoundResultsTable.jsx
+++ b/client/src/components/RoundResults/RoundResultsTable.jsx
@@ -58,13 +58,24 @@ const RoundResultsTable = memo(
     competitionId,
     onResultClick,
     forecastView,
+    advancementCondition,
   }) => {
     const smScreen = useMediaQuery((theme) => theme.breakpoints.up("sm"));
     const mdScreen = useMediaQuery((theme) => theme.breakpoints.up("md"));
 
-    const stats = orderedResultStats(eventId, format, forecastView);
+    const stats = orderedResultStats(
+      eventId,
+      format,
+      forecastView,
+      advancementCondition
+    );
 
-    const viewResults = resultsForView(results, format, forecastView);
+    const viewResults = resultsForView(
+      results,
+      format,
+      forecastView,
+      advancementCondition
+    );
     return (
       <Paper>
         <Table size="small">

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -42,13 +42,13 @@ export function orderedResultStats(
   stats = sortBy === "best" ? stats : stats.reverse();
   if (forecastView && eventId != "333fm") {
     stats.push({
-      name: "For 1st",
+      name: "For 1",
       field: "forFirst",
     });
     stats.push({
       name: advancementCondition
-        ? "Adv. [" + advancementCondition.level + "]"
-        : "For 3rd",
+        ? "For " + advancementCondition.level
+        : "For 3",
       field: "forAdvance",
     });
   }
@@ -184,7 +184,7 @@ export function resultsForView(
   }
 
   // Default to podium (top 3) if no advancement condition
-  let advancementIndex = advancementCondition?.level ?? 3;
+  let advancementRanking = advancementCondition?.level ?? 3;
   if (resultsForView.length > 1 && eventId != "333fm") {
     for (let i = 0; i < resultsForView.length; i++) {
       let result = resultsForView[i];
@@ -202,13 +202,13 @@ export function resultsForView(
           resultsForView[firstIndex]
         );
         // Same as 1st, compare against (i+1)th place for current ith place.
-        let advIndex =
-          i < advancementIndex ? advancementIndex : advancementIndex - 1;
-        if (advIndex < resultsForView.length) {
+        let advancementIndex =
+          i < advancementRanking ? advancementRanking : advancementRanking - 1;
+        if (advancementIndex < resultsForView.length) {
           result.forAdvance = timeNeededToOvertake(
             result,
             format,
-            resultsForView[advIndex]
+            resultsForView[advancementIndex]
           );
         }
       }

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -109,7 +109,7 @@ function sum(values) {
  *  * `projectedAverage` - average projection based on the current
  *    attempts, if any
  *  * `forFirst` - time needed to overtake 1st place
- *  * `forAdvance` - time needed to overtake 3rd place
+ *  * `forAdvance` - time needed to advance
  *
  */
 export function resultsForView(

--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -185,7 +185,7 @@ export function resultsForView(
   }
 
   // Default to podium (top 3) if no advancement condition
-  let advancementIndex = advancementCondition.level ?? 3;
+  let advancementIndex = advancementCondition?.level ?? 3;
   if (resultsForView.length > 1) {
     for (let i = 0; i < resultsForView.length; i++) {
       let result = resultsForView[i];
@@ -203,13 +203,13 @@ export function resultsForView(
           resultsForView[firstIndex]
         );
         // Same as 1st, compare against (i+1)th place for current ith place.
-        let thirdIndex =
+        let advIndex =
           i < advancementIndex ? advancementIndex : advancementIndex - 1;
-        if (thirdIndex < resultsForView.length) {
+        if (advIndex < resultsForView.length) {
           result.forAdvance = timeNeededToOvertake(
             result,
             format,
-            resultsForView[thirdIndex]
+            resultsForView[advIndex]
           );
         }
       }

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -301,7 +301,12 @@ describe("viewResults", () => {
         average: 0,
       },
     ];
-    const viewResults = resultsForView(results, format, true, advancementCondition);
+    const viewResults = resultsForView(
+      results,
+      format,
+      true,
+      advancementCondition
+    );
     expect(viewResults[0]).toMatchObject({
       forAdvance: 104,
     });

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -6,7 +6,7 @@ import {
 } from "../result";
 
 describe("orderedResultStats", () => {
-  it("returns 'forFirst' and 'forThird' when forecase view is enabled", () => {
+  it("returns 'forFirst' and 'forAdvance' when forecase view is enabled", () => {
     const eventId = "333";
     const format = { numberOfAttempts: 5, sortBy: "average" };
     const bestStat = {
@@ -27,7 +27,7 @@ describe("orderedResultStats", () => {
       averageStat,
       bestStat,
       { name: "For 1st", field: "forFirst" },
-      { name: "For 3rd", field: "forThird" },
+      { name: "For 3rd", field: "forAdvance" },
     ]);
   });
 });
@@ -189,7 +189,7 @@ describe("viewResults", () => {
     });
   });
 
-  it("sets forFirst/forThird based on times needed to achieve 1st/3rd", () => {
+  it("sets forFirst/forAdvance based on times needed to achieve 1st/3rd", () => {
     const format = { numberOfAttempts: 3 };
     const results = [
       {
@@ -223,26 +223,61 @@ describe("viewResults", () => {
         average: 104,
       },
     ];
-    const viewResults = resultsForView(results, format, true);
+    const viewResults = resultsForView(results, format, true, null);
     expect(viewResults[0]).toMatchObject({
       forFirst: 102,
-      forThird: 106,
+      forAdvance: 106,
     });
     expect(viewResults[1]).toMatchObject({
       forFirst: 99,
-      forThird: 105,
+      forAdvance: 105,
     });
     expect(viewResults[2]).toMatchObject({
       forFirst: 98,
-      forThird: 104,
+      forAdvance: 104,
     });
     expect(viewResults[3]).toMatchObject({
       forFirst: 97,
-      forThird: 101,
+      forAdvance: 101,
     });
     expect(viewResults[4]).toMatchObject({
       forFirst: 0,
-      forThird: 0,
+      forAdvance: 0,
+    });
+  });
+
+  it("sets for advance based on times needed to advance", () => {
+    const advancementCondition = { level: 2 };
+    const format = { numberOfAttempts: 3 };
+    const results = [
+      {
+        ranking: 1,
+        attempts: [{ result: 100 }],
+        best: 100,
+        average: 0,
+      },
+      {
+        ranking: 2,
+        attempts: [{ result: 101 }],
+        best: 101,
+        average: 0,
+      },
+      {
+        ranking: 3,
+        attempts: [{ result: 102 }],
+        best: 102,
+        average: 0,
+      },
+    ];
+    const viewResults = resultsForView(results, format, true, advancementCondition);
+    expect(viewResults[0]).toMatchObject({
+      forAdvance: 104,
+    });
+    expect(viewResults[1]).toMatchObject({
+      forAdvance: 103,
+    });
+    expect(viewResults[2]).toMatchObject({
+      forAdvance: 100,
     });
   });
 });

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -26,8 +26,8 @@ describe("orderedResultStats", () => {
     expect(orderedResultStats(eventId, format, true)).toMatchObject([
       averageStat,
       bestStat,
-      { name: "For 1st", field: "forFirst" },
-      { name: "For 3rd", field: "forAdvance" },
+      { name: "For 1", field: "forFirst" },
+      { name: "For 3", field: "forAdvance" },
     ]);
   });
 });

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -192,7 +192,7 @@ describe("viewResults", () => {
     });
   });
 
-  it("deesn't set forFirst/forThird for fewest moves", () => {
+  it("deesn't set forFirst/forAdvance for fewest moves", () => {
     const event333fm = "333fm";
     const format = { numberOfAttempts: 3 };
     const results = [
@@ -212,11 +212,11 @@ describe("viewResults", () => {
     const viewResults = resultsForView(results, event333fm, format, true);
     expect(viewResults[0]).toMatchObject({
       forFirst: 0,
-      forThird: 0,
+      forAdvance: 0,
     });
     expect(viewResults[1]).toMatchObject({
       forFirst: 0,
-      forThird: 0,
+      forAdvance: 0,
     });
   });
 
@@ -279,6 +279,7 @@ describe("viewResults", () => {
   });
 
   it("sets for advance based on times needed to advance", () => {
+    const event333 = "333";
     const advancementCondition = { level: 2 };
     const format = { numberOfAttempts: 3 };
     const results = [
@@ -303,6 +304,7 @@ describe("viewResults", () => {
     ];
     const viewResults = resultsForView(
       results,
+      event333,
       format,
       true,
       advancementCondition


### PR DESCRIPTION
Specifically adding this functionality for 3x3 semifinals at worlds. This will be treated similar to the other finals and would like to be able to see what people need to get in order to jump into the top 16.

Coded in a way that is generic for all rounds with a "ranking" advancement condition type