### PR TITLE
Disable forecast view for complete rounds

### DIFF
--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -80,6 +80,8 @@ export function forecastViewSupported(round) {
   return (
     // Only relevant for rounds sorted by average
     round.format.sortBy != "best" &&
+    // Only relevant for incomplete rounds
+    !round.finished &&
     // Only final rounds or rounds with a ranking based
     // advancement condition are supported
     (round.advancementCondition === null ||

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -39,11 +39,13 @@ describe("forecastViewSupported", () => {
       false
     );
   });
+
   it("returns false for finished rounds", () => {
     expect(
       forecastViewSupported({ format: { sortBy: "average" }, finished: true })
     ).toEqual(false);
   });
+
   it("returns true for finals and 'ranking' advancement type", () => {
     expect(
       forecastViewSupported({
@@ -54,6 +56,7 @@ describe("forecastViewSupported", () => {
         advancementCondition: null,
       })
     ).toEqual(true);
+
     expect(
       forecastViewSupported({
         format: {
@@ -63,6 +66,7 @@ describe("forecastViewSupported", () => {
         advancementCondition: { type: "ranking" },
       })
     ).toEqual(true);
+
     expect(
       forecastViewSupported({
         format: {

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -1,4 +1,5 @@
 import {
+  forecastViewSupported,
   formatAttemptResultForView,
   resultsForView,
   orderedResultStats,
@@ -29,6 +30,48 @@ describe("orderedResultStats", () => {
       { name: "For 1", field: "forFirst" },
       { name: "For 3", field: "forAdvance" },
     ]);
+  });
+});
+
+describe("forecastViewSupported", () => {
+  it("returns false for rounds sorted by best", () => {
+    expect(forecastViewSupported({ format: { sortBy: "best" } })).toEqual(
+      false
+    );
+  });
+  it("returns false for finished rounds", () => {
+    expect(
+      forecastViewSupported({ format: { sortBy: "average" }, finished: true })
+    ).toEqual(false);
+  });
+  it("returns true for finals and 'ranking' advancement type", () => {
+    expect(
+      forecastViewSupported({
+        format: {
+          sortBy: "average",
+        },
+        finished: false,
+        advancementCondition: null,
+      })
+    ).toEqual(true);
+    expect(
+      forecastViewSupported({
+        format: {
+          sortBy: "average",
+        },
+        finished: false,
+        advancementCondition: { type: "ranking" },
+      })
+    ).toEqual(true);
+    expect(
+      forecastViewSupported({
+        format: {
+          sortBy: "average",
+        },
+        finished: false,
+        advancementCondition: { type: "limit" },
+      })
+    ).toEqual(false);
   });
 });
 


### PR DESCRIPTION
Accidentally deleted this in my latest change. Adding back with tests