### PR TITLE
Change order of stats columns in forecast view

### DIFF
--- a/client/src/lib/result.js
+++ b/client/src/lib/result.js
@@ -43,11 +43,6 @@ export function orderedResultStats(
   ];
   stats = sortBy === "best" ? stats : stats.reverse();
 
-  if (forecastView && numberOfAttempts === 5) {
-    stats.push({ name: "BPA", field: "bestPossibleAverage" });
-    stats.push({ name: "WPA", field: "worstPossibleAverage" });
-  }
-
   if (forecastView && eventId != "333fm") {
     stats.push({ name: "For 1", field: "forFirst" });
     stats.push({
@@ -57,6 +52,12 @@ export function orderedResultStats(
       field: "forAdvance",
     });
   }
+
+  if (forecastView && numberOfAttempts === 5) {
+    stats.push({ name: "BPA", field: "bestPossibleAverage" });
+    stats.push({ name: "WPA", field: "worstPossibleAverage" });
+  }
+
   return stats;
 }
 

--- a/client/src/lib/tests/result.test.js
+++ b/client/src/lib/tests/result.test.js
@@ -51,10 +51,10 @@ describe("orderedResultStats", () => {
         field: "best",
         recordTagField: "singleRecordTag",
       },
-      { name: "BPA", field: "bestPossibleAverage" },
-      { name: "WPA", field: "worstPossibleAverage" },
       { name: "For 1", field: "forFirst" },
       { name: "For 3", field: "forAdvance" },
+      { name: "BPA", field: "bestPossibleAverage" },
+      { name: "WPA", field: "worstPossibleAverage" },
     ]);
 
     const formatMo3 = { numberOfAttempts: 3, sortBy: "average" };


### PR DESCRIPTION
BPA/WPA are only valid when 4/5 solves are complete, while For1/ForX are always valid. Change For1/ForX to go first