### PR TITLE
Show only advancing results in projector with forecast view

### DIFF
--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -134,17 +134,18 @@ function ResultsProjector({
         setStatus(STATUS.SHOWING);
         setTopResultIndex((topResultIndex) => {
           const newIndex = topResultIndex + getNumberOfRows();
-          const maxIndex =
-            forecastView && advancementCondition
-              ? advancementCondition.level * 2
-              : nonemptyResults.length;
-          return newIndex >= maxIndex ? 0 : newIndex;
+          return newIndex > nonemptyResults.length ||
+            (forecastView &&
+              !nonemptyResults[topResultIndex].advancing &&
+              !nonemptyResults[newIndex].advancing)
+            ? o
+            : newIndex;
         });
       }, DURATION.HIDING);
       return () => clearTimeout(timeout);
     }
     throw new Error(`Unrecognized status: ${status}`);
-  }, [status, nonemptyResults.length]);
+  }, [status, nonemptyResults, forecastView]);
 
   return (
     <Dialog

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -70,6 +70,7 @@ const STATUS = {
 
 const DURATION = {
   SHOWN: 10 * 1000,
+  FORECAST_SHOWN: 20 * 1000,
   SHOWING: 1000,
   HIDING: 1000,
 };
@@ -111,9 +112,12 @@ function ResultsProjector({
     }
     if (status === STATUS.SHOWN) {
       if (nonemptyResults.length > getNumberOfRows()) {
-        const timeout = setTimeout(() => {
-          setStatus(STATUS.HIDING);
-        }, DURATION.SHOWN);
+        const timeout = setTimeout(
+          () => {
+            setStatus(STATUS.HIDING);
+          },
+          forecastView ? DURATION.FORECAST_SHOWN : DURATION.SHOWN
+        );
         return () => clearTimeout(timeout);
       } else {
         return;
@@ -130,7 +134,11 @@ function ResultsProjector({
         setStatus(STATUS.SHOWING);
         setTopResultIndex((topResultIndex) => {
           const newIndex = topResultIndex + getNumberOfRows();
-          return newIndex >= nonemptyResults.length ? 0 : newIndex;
+          const maxIndex =
+            forecastView && advancementCondition
+              ? advancementCondition.level * 2
+              : nonemptyResults.length;
+          return newIndex >= maxIndex ? 0 : newIndex;
         });
       }, DURATION.HIDING);
       return () => clearTimeout(timeout);
@@ -222,7 +230,7 @@ function ResultsProjector({
                   timeout={{ enter: DURATION.SHOWING, exit: DURATION.HIDING }}
                   style={
                     status === STATUS.SHOWING
-                      ? { transitionDelay: `${index * 150}ms` }
+                      ? { transitionDelay: `${index * (forecastView ? 50 : 150)}ms` }
                       : {}
                   }
                   in={[STATUS.SHOWING, STATUS.SHOWN, STATUS.PAUSED].includes(

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -230,7 +230,7 @@ function ResultsProjector({
                   timeout={{ enter: DURATION.SHOWING, exit: DURATION.HIDING }}
                   style={
                     status === STATUS.SHOWING
-                      ? { 
+                      ? {
                           transitionDelay: `${index * (forecastView ? 50 : 150)}ms`,
                         }
                       : {}

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -105,8 +105,14 @@ function ResultsProjector({
     forecastView,
     advancementCondition,
   ).filter((result) => result.attempts.length > 0);
+ 
+  let nonemptyResultsRef = nonemptyResults;
+  useEffect(() => {
+    nonemptyResultsRef = nonemptyResults;
+  }, [nonemptyResults]);
 
   useEffect(() => {
+    const nonemptyResults = nonemptyResultsRef;
     if (status === STATUS.PAUSED) {
       return;
     }
@@ -135,6 +141,9 @@ function ResultsProjector({
         setTopResultIndex((topResultIndex) => {
           const newIndex = topResultIndex + getNumberOfRows();
           return newIndex > nonemptyResults.length ||
+            // When forecast view is enabled, the focus is usually on the advancing
+            // results, so we only show a single page of non-advancing results and
+            // roll back to the first page afterwards.
             (forecastView &&
               !nonemptyResults[topResultIndex].advancing &&
               !nonemptyResults[newIndex].advancing)
@@ -145,7 +154,7 @@ function ResultsProjector({
       return () => clearTimeout(timeout);
     }
     throw new Error(`Unrecognized status: ${status}`);
-  }, [status, nonemptyResults, forecastView]);
+  }, [status, forecastView]);
 
   return (
     <Dialog

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -105,7 +105,7 @@ function ResultsProjector({
     forecastView,
     advancementCondition,
   ).filter((result) => result.attempts.length > 0);
- 
+
   let nonemptyResultsRef = nonemptyResults;
   useEffect(() => {
     nonemptyResultsRef = nonemptyResults;

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -138,7 +138,7 @@ function ResultsProjector({
             (forecastView &&
               !nonemptyResults[topResultIndex].advancing &&
               !nonemptyResults[newIndex].advancing)
-            ? o
+            ? 0
             : newIndex;
         });
       }, DURATION.HIDING);

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import {
   AppBar,
@@ -106,13 +106,13 @@ function ResultsProjector({
     advancementCondition,
   ).filter((result) => result.attempts.length > 0);
 
-  let nonemptyResultsRef = nonemptyResults;
+  const nonemptyResultsRef = useRef(nonemptyResults);
   useEffect(() => {
-    nonemptyResultsRef = nonemptyResults;
-  }, [nonemptyResults]);
+    nonemptyResultsRef.current = nonemptyResults;
+  });
 
   useEffect(() => {
-    const nonemptyResults = nonemptyResultsRef;
+    const nonemptyResults = nonemptyResultsRef.current;
     if (status === STATUS.PAUSED) {
       return;
     }

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -116,7 +116,7 @@ function ResultsProjector({
           () => {
             setStatus(STATUS.HIDING);
           },
-          forecastView ? DURATION.FORECAST_SHOWN : DURATION.SHOWN
+          forecastView ? DURATION.FORECAST_SHOWN : DURATION.SHOWN,
         );
         return () => clearTimeout(timeout);
       } else {
@@ -230,7 +230,9 @@ function ResultsProjector({
                   timeout={{ enter: DURATION.SHOWING, exit: DURATION.HIDING }}
                   style={
                     status === STATUS.SHOWING
-                      ? { transitionDelay: `${index * (forecastView ? 50 : 150)}ms` }
+                      ? { 
+                          transitionDelay: `${index * (forecastView ? 50 : 150)}ms`,
+                        }
                       : {}
                   }
                   in={[STATUS.SHOWING, STATUS.SHOWN, STATUS.PAUSED].includes(


### PR DESCRIPTION
Forecast view is specifically for showing projected results in a real time environment. 

For projector view, linger on each page for longer, populate the page faster, and only show results that could potentially advance.