### PR TITLE
Persist batch mode setting

### DIFF
--- a/client/src/components/admin/AdminRound/AdminRoundContent.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.jsx
@@ -41,12 +41,15 @@ const ENTER_RESULTS = gql`
 `;
 
 const IS_BATCH_MODE_KEY = `wca-live:is-batch-mode`;
+
 /**
  * Persist whether batch mode is toggled on, in case people navigate
  * or refresh the page
+ * @returns {boolean}
  */
 function getStoreIsBatchMode() {
-  return localStorage.getItem(IS_BATCH_MODE_KEY);
+  const json = localStorage.getItem(IS_BATCH_MODE_KEY);
+  return json ? JSON.parse(json) : false;
 }
 
 function setStoreIsBatchMode(isBatchMode) {
@@ -57,7 +60,6 @@ function setStoreIsBatchMode(isBatchMode) {
  * Persist batch results in local storage, in case people navigate
  * or refresh the page
  */
-
 function getStoreBatchResults(roundId) {
   const json = localStorage.getItem(`wca-live:batch-results:${roundId}`);
   return json ? JSON.parse(json) : [];
@@ -87,7 +89,7 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
     getStoreBatchResults(round.id),
   );
   const [isBatchMode, setIsBatchMode] = useState(
-    batchResults.length > 0 || getStoreIsBatchMode(),
+    () => batchResults.length > 0 || getStoreIsBatchMode(),
   );
   const formContainerRef = useRef(null);
 

--- a/client/src/components/admin/AdminRound/AdminRoundContent.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.jsx
@@ -53,7 +53,7 @@ function getStoreIsBatchMode() {
 }
 
 function setStoreIsBatchMode(isBatchMode) {
-  localStorage.setItem(IS_BATCH_MODE_KEY, isBatchMode);
+  localStorage.setItem(IS_BATCH_MODE_KEY, JSON.stringify(isBatchMode));
 }
 
 /**

--- a/client/src/components/admin/AdminRound/AdminRoundContent.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.jsx
@@ -50,7 +50,7 @@ function getStoreIsBatchMode() {
 }
 
 function setStoreIsBatchMode(isBatchMode) {
-  localStorage.setItem(IS_BATCH_MODE_KEY, isBatchMode)
+  localStorage.setItem(IS_BATCH_MODE_KEY, isBatchMode);
 }
 
 /**
@@ -86,7 +86,9 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
   const [batchResults, setBatchResults] = useState(() =>
     getStoreBatchResults(round.id),
   );
-  const [isBatchMode, setIsBatchMode] = useState(batchResults.length > 0 || getStoreIsBatchMode());
+  const [isBatchMode, setIsBatchMode] = useState(
+    batchResults.length > 0 || getStoreIsBatchMode(),
+  );
   const formContainerRef = useRef(null);
 
   const [enterResults, { loading }] = useMutation(ENTER_RESULTS, {

--- a/client/src/components/admin/AdminRound/AdminRoundContent.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.jsx
@@ -40,8 +40,23 @@ const ENTER_RESULTS = gql`
   ${ADMIN_ROUND_RESULT_FRAGMENT}
 `;
 
-// Persist batch results in local storage, in case people navigate
-// or refresh the page
+const IS_BATCH_MODE_KEY = `wca-live:is-batch-mode`;
+/**
+ * Persist whether batch mode is toggled on, in case people navigate
+ * or refresh the page
+ */
+function getStoreIsBatchMode() {
+  return localStorage.getItem(IS_BATCH_MODE_KEY);
+}
+
+function setStoreIsBatchMode(isBatchMode) {
+  localStorage.setItem(IS_BATCH_MODE_KEY, isBatchMode)
+}
+
+/**
+ * Persist batch results in local storage, in case people navigate
+ * or refresh the page
+ */
 
 function getStoreBatchResults(roundId) {
   const json = localStorage.getItem(`wca-live:batch-results:${roundId}`);
@@ -71,7 +86,7 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
   const [batchResults, setBatchResults] = useState(() =>
     getStoreBatchResults(round.id),
   );
-  const [isBatchMode, setIsBatchMode] = useState(batchResults.length > 0);
+  const [isBatchMode, setIsBatchMode] = useState(batchResults.length > 0 || getStoreIsBatchMode());
   const formContainerRef = useRef(null);
 
   const [enterResults, { loading }] = useMutation(ENTER_RESULTS, {
@@ -189,7 +204,10 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
               control={
                 <Checkbox
                   checked={isBatchMode}
-                  onChange={(event) => setIsBatchMode(event.target.checked)}
+                  onChange={(event) => {
+                    setIsBatchMode(event.target.checked);
+                    setStoreIsBatchMode(event.target.checked);
+                  }}
                   disabled={batchResults.length > 0}
                 />
               }


### PR DESCRIPTION
When entering scorecards, it is often necessary to refresh the page (e.g. to get new data without accidentally overwriting someone else's work). Currently this causes batch mode to revert to the off state (assuming you had no in-progress batch, which is usually the case when refreshing). At a venue with poor internet (and/or high data needs), this causes extra frustration when accidentally entering the first scorecard after refreshing.

Fixes https://github.com/thewca/wca-live/issues/273.