### PR TITLE
Batch mode highlight

### DIFF
--- a/client/src/components/admin/AdminRound/AdminRoundContent.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.jsx
@@ -169,10 +169,18 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
 
   return (
     <>
-      <Grid container direction="row" spacing={2}>
-        <Grid 
-          sx={isBatchMode ? {backgroundColor: "rgba(238, 210, 2, 0.2)"} : {}}
-          item xs={12} md={3} ref={formContainerRef}>
+      <Grid sx={{ marginLeft: "-8px" }} container direction="row" spacing={2}>
+        <Grid
+          sx={{
+            paddingLeft: "8px",
+            paddingRight: "8px",
+            backgroundColor: isBatchMode ? "rgba(238, 210, 2, 0.2)" : "",
+          }}
+          item
+          xs={12}
+          md={3}
+          ref={formContainerRef}
+        >
           <ResultAttemptsForm
             result={editedResult}
             results={round.results}
@@ -232,7 +240,18 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
             )}
           </Box>
         </Grid>
-        <Grid item xs={12} md={9} container direction="column" spacing={1}>
+        <Grid
+          sx={{
+            paddingLeft: "8px",
+            paddingRight: "8px",
+          }}
+          item
+          xs={12}
+          md={9}
+          container
+          direction="column"
+          spacing={1}
+        >
           <Grid item>
             <AdminRoundToolbar round={round} competitionId={competitionId} />
           </Grid>

--- a/client/src/components/admin/AdminRound/AdminRoundContent.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.jsx
@@ -170,7 +170,9 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
   return (
     <>
       <Grid container direction="row" spacing={2}>
-        <Grid item xs={12} md={3} ref={formContainerRef}>
+        <Grid 
+          sx={isBatchMode ? {backgroundColor: "rgba(238, 210, 2, 0.2)"} : {}}
+          item xs={12} md={3} ref={formContainerRef}>
           <ResultAttemptsForm
             result={editedResult}
             results={round.results}


### PR DESCRIPTION
Make it easier to tell at a glance whether you're currently entering scores in batch mode.  This can be a problem on smaller screen sizes, or when a user has increased their font size: the Batch Mode checkbox is not in view while the input boxes are focused.

I am ambivalent on the color, just wanted something that's bright enough colorblind/vision-impaired people can still notice it but not so bright that it's annoying.

### References

Small screen dark mode: 
<img width="540" alt="Screenshot 2025-07-08 at 12 05 47 PM" src="https://github.com/user-attachments/assets/14519c15-ba0a-49e2-b393-58e4f72e40eb" />

Larger screen light mode:
<img width="577" alt="Screenshot 2025-07-08 at 12 01 38 PM" src="https://github.com/user-attachments/assets/85e9d2a1-8d00-4885-bae6-0427442ff8eb" />

Refs https://github.com/thewca/wca-live/issues/273.