### PR TITLE
Give warning for duplicate results

### DIFF
--- a/client/src/components/admin/AdminRound/AdminRoundContent.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.jsx
@@ -207,7 +207,7 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
     setCombinedResults(
       combineResultsAndBatchResults(round.results, batchResults),
     );
-  }, [round.id, batchResults]);
+  }, [round, batchResults]);
 
   return (
     <>

--- a/client/src/components/admin/AdminRound/AdminRoundContent.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.jsx
@@ -86,11 +86,11 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
     onError: apolloErrorHandler,
   });
 
-  function handleResultAttemptsSubmit(attempts) {
+  function handleResultAttemptsSubmit(attempts, person) {
     if (isBatchMode) {
       setBatchResults([
         ...batchResults.filter((result) => result.id !== editedResult.id),
-        { id: editedResult.id, attempts, enteredAt: nowISOString() },
+        { id: editedResult.id, attempts, person, enteredAt: nowISOString() },
       ]);
       setEditedResult(null);
     } else {

--- a/client/src/components/admin/AdminRound/AdminRoundContent.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundContent.jsx
@@ -174,6 +174,7 @@ function AdminRoundContent({ round, competitionId, officialWorldRecords }) {
           <ResultAttemptsForm
             result={editedResult}
             results={round.results}
+            batchResults={batchResults}
             onResultChange={setEditedResult}
             eventId={round.competitionEvent.event.id}
             format={round.format}

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -25,6 +25,7 @@ import {
 function ResultAttemptsForm({
   result,
   results,
+  batchResults,
   onResultChange,
   eventId,
   format,
@@ -100,7 +101,7 @@ function ResultAttemptsForm({
       attemptResults,
       eventId,
       officialWorldRecords,
-      results
+      [...results, ...batchResults]
     );
 
     if (submissionWarning) {

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -100,6 +100,7 @@ function ResultAttemptsForm({
       attemptResults,
       eventId,
       officialWorldRecords,
+      results
     );
 
     if (submissionWarning) {

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -97,11 +97,16 @@ function ResultAttemptsForm({
   }
 
   function confirmSubmission() {
+    // We don't want to show a duplicate warning if the user is submitting
+    // already-entered results for the correct competitor.  This is often used
+    // as a quick way to refresh data without refreshing the whole page.
+    const resultsToCheck = combinedResults.filter((res) => res.id !== result.id);
+
     const submissionWarning = attemptResultsWarning(
       attemptResults,
       eventId,
       officialWorldRecords,
-      combinedResults,
+      resultsToCheck,
     );
 
     if (submissionWarning) {

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -25,7 +25,7 @@ import {
 function ResultAttemptsForm({
   result,
   results,
-  batchResults,
+  combinedResults, // combined results and batchResults array
   onResultChange,
   eventId,
   format,
@@ -101,7 +101,7 @@ function ResultAttemptsForm({
       attemptResults,
       eventId,
       officialWorldRecords,
-      [...results, ...batchResults],
+      combinedResults,
     );
 
     if (submissionWarning) {

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -92,7 +92,7 @@ function ResultAttemptsForm({
       const attempts = trimTrailingSkipped(attemptResults).map((result) => ({
         result,
       }));
-      onSubmit(attempts);
+      onSubmit(attempts, result.person);
     });
   }
 
@@ -101,7 +101,7 @@ function ResultAttemptsForm({
       attemptResults,
       eventId,
       officialWorldRecords,
-      [...results, ...batchResults]
+      [...results, ...batchResults],
     );
 
     if (submissionWarning) {

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -490,7 +490,10 @@ export function attemptResultsWarning(
     if (["333fm"].indexOf(eventId) === -1) {
       const matches = findAllMatchingResults(attemptResults, results);
       if (matches.length > 0) {
-        const matchesString = matches.map((match) => `${match.person.name} (${match.person.id})`).join(", ");
+        // Batch entries don't have `person` attributes, just `id`
+        const matchesString = matches.map((match) => 
+          `${match.person ? match.person.name : "[batched competitor]"} (${match.id})`
+        ).join(", ");
         return {
           description: `The result you're trying to submit matches all results for
             the following competitor${matches.length > 1 ? "s" : ""}: ${matchesString}.
@@ -566,15 +569,17 @@ function checkForDnsFollowedByValidResult(attemptResults) {
  * Check whether an attempt matches an existing attempt exactly.
  */
 function findAllMatchingResults(attemptResults, results) {
+  const filteredAttemptResults = trimTrailingSkipped(attemptResults);
+
   const matches = results.filter(
     (result) => {
-      if (result.attempts.length !== attemptResults.length) {
+      if (result.attempts.length !== filteredAttemptResults.length) {
         return false;
       }
 
       let numDnfResults = 0;
       for (let i = 0; i < result.attempts.length; i++) {
-        if (result.attempts[i].result !== attemptResults[i]) {
+        if (result.attempts[i].result !== filteredAttemptResults[i]) {
           return false;
         }
         if (result.attempts[i].result === DNF_VALUE) {

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -490,10 +490,9 @@ export function attemptResultsWarning(
     if (["333fm"].indexOf(eventId) === -1) {
       const matches = findAllMatchingResults(attemptResults, results);
       if (matches.length > 0) {
-        // Batch entries don't have `person` attributes, just `id`
-        const matchesString = matches.map((match) => 
-          `${match.person ? match.person.name : "[batched competitor]"} (${match.id})`
-        ).join(", ");
+        const matchesString = matches
+          .map((match) => `${match.person.name} (${match.person.id})`)
+          .join(", ");
         return {
           description: `The result you're trying to submit matches all results for
             the following competitor${matches.length > 1 ? "s" : ""}: ${matchesString}.
@@ -571,28 +570,26 @@ function checkForDnsFollowedByValidResult(attemptResults) {
 function findAllMatchingResults(attemptResults, results) {
   const filteredAttemptResults = trimTrailingSkipped(attemptResults);
 
-  const matches = results.filter(
-    (result) => {
-      if (result.attempts.length !== filteredAttemptResults.length) {
-        return false;
-      }
-
-      let numDnfResults = 0;
-      for (let i = 0; i < result.attempts.length; i++) {
-        if (result.attempts[i].result !== filteredAttemptResults[i]) {
-          return false;
-        }
-        if (result.attempts[i].result === DNF_VALUE) {
-          numDnfResults++;
-        }
-      }
-      // Exclude all-DNF results since ties are common
-      if (numDnfResults === result.attempts.length) {
-        return false;
-      }
-
-      return true;
+  const matches = results.filter((result) => {
+    if (result.attempts.length !== filteredAttemptResults.length) {
+      return false;
     }
-  )
+
+    let numDnfResults = 0;
+    for (let i = 0; i < result.attempts.length; i++) {
+      if (result.attempts[i].result !== filteredAttemptResults[i]) {
+        return false;
+      }
+      if (result.attempts[i].result === DNF_VALUE) {
+        numDnfResults++;
+      }
+    }
+    // Exclude all-DNF results since ties are common
+    if (numDnfResults === result.attempts.length) {
+      return false;
+    }
+
+    return true;
+  });
   return matches;
 }

--- a/client/src/lib/attempt-result.js
+++ b/client/src/lib/attempt-result.js
@@ -486,8 +486,7 @@ export function attemptResultsWarning(
 
     // Check whether this result is a duplicate of existing results in the same round.
     // Excludes FMC and all-DNF results since ties are common.
-    // TODO: Does NOT check the in-progress batch, if any.
-    if (["333fm"].indexOf(eventId) === -1) {
+    if (eventId !== "333fm" && completeAttempts.length > 0) {
       const matches = findAllMatchingResults(attemptResults, results);
       if (matches.length > 0) {
         const matchesString = matches
@@ -574,22 +573,13 @@ function findAllMatchingResults(attemptResults, results) {
     if (result.attempts.length !== filteredAttemptResults.length) {
       return false;
     }
-
-    let numDnfResults = 0;
     for (let i = 0; i < result.attempts.length; i++) {
       if (result.attempts[i].result !== filteredAttemptResults[i]) {
         return false;
       }
-      if (result.attempts[i].result === DNF_VALUE) {
-        numDnfResults++;
-      }
     }
-    // Exclude all-DNF results since ties are common
-    if (numDnfResults === result.attempts.length) {
-      return false;
-    }
-
     return true;
   });
+
   return matches;
 }

--- a/client/src/lib/tests/attempt-result.test.js
+++ b/client/src/lib/tests/attempt-result.test.js
@@ -536,6 +536,40 @@ describe("attemptResultsWarning", () => {
       attemptResultsWarning(attemptResults, "333fm", worldRecords),
     ).toEqual(null);
   });
+
+  it("complains about exact duplicate results", () => {
+    const attemptResults = [500, 600, 700, 800, 900];
+    const existingResults = [
+      {attempts: [{result: 500}, {result: 600}, {result: 700}, {result: 800}, {result: 900}], person: {id: 2, name: "Person 2"}}
+    ];
+    expect(
+      attemptResultsWarning(attemptResults, "333", [], existingResults)
+    ).toMatchObject({
+      description: `The result you're trying to submit matches all results for
+            the following competitor: Person 2 (2).
+            Please check that the results are accurate.`,
+    });
+  });
+
+  it("does not check for duplicates in FMC", () => {
+    const attemptResults = [25, 26];
+    const existingResults = [
+      {attempts: [{result: 25}, {result: 26}], person: {id: 2, name: "Person 2"}}
+    ];
+    expect(
+      attemptResultsWarning(attemptResults, "333fm", [], existingResults)
+    ).toEqual(null);
+  });
+
+  it("does not warn about all-DNF duplicates", () => {
+    const attemptResults = [-1, -1, -1, -1, -1];
+    const existingResults = [
+      {attempts: [{result: -1}, {result: -1}, {result: -1}, {result: -1}, {result: -1}], person: {id: 2, name: "Person 2"}}
+    ];
+    expect(
+      attemptResultsWarning(attemptResults, "333fm", [], existingResults)
+    ).toEqual(null);
+  });
 });
 
 describe("applyTimeLimit", () => {

--- a/client/src/lib/tests/attempt-result.test.js
+++ b/client/src/lib/tests/attempt-result.test.js
@@ -588,7 +588,7 @@ describe("attemptResultsWarning", () => {
       },
     ];
     expect(
-      attemptResultsWarning(attemptResults, "333fm", [], existingResults),
+      attemptResultsWarning(attemptResults, "333", [], existingResults),
     ).toEqual(null);
   });
 });

--- a/client/src/lib/tests/attempt-result.test.js
+++ b/client/src/lib/tests/attempt-result.test.js
@@ -540,10 +540,19 @@ describe("attemptResultsWarning", () => {
   it("complains about exact duplicate results", () => {
     const attemptResults = [500, 600, 700, 800, 900];
     const existingResults = [
-      {attempts: [{result: 500}, {result: 600}, {result: 700}, {result: 800}, {result: 900}], person: {id: 2, name: "Person 2"}}
+      {
+        attempts: [
+          { result: 500 },
+          { result: 600 },
+          { result: 700 },
+          { result: 800 },
+          { result: 900 },
+        ],
+        person: { id: 2, name: "Person 2" },
+      },
     ];
     expect(
-      attemptResultsWarning(attemptResults, "333", [], existingResults)
+      attemptResultsWarning(attemptResults, "333", [], existingResults),
     ).toMatchObject({
       description: `The result you're trying to submit matches all results for
             the following competitor: Person 2 (2).
@@ -554,20 +563,32 @@ describe("attemptResultsWarning", () => {
   it("does not check for duplicates in FMC", () => {
     const attemptResults = [25, 26];
     const existingResults = [
-      {attempts: [{result: 25}, {result: 26}], person: {id: 2, name: "Person 2"}}
+      {
+        attempts: [{ result: 25 }, { result: 26 }],
+        person: { id: 2, name: "Person 2" },
+      },
     ];
     expect(
-      attemptResultsWarning(attemptResults, "333fm", [], existingResults)
+      attemptResultsWarning(attemptResults, "333fm", [], existingResults),
     ).toEqual(null);
   });
 
   it("does not warn about all-DNF duplicates", () => {
     const attemptResults = [-1, -1, -1, -1, -1];
     const existingResults = [
-      {attempts: [{result: -1}, {result: -1}, {result: -1}, {result: -1}, {result: -1}], person: {id: 2, name: "Person 2"}}
+      {
+        attempts: [
+          { result: -1 },
+          { result: -1 },
+          { result: -1 },
+          { result: -1 },
+          { result: -1 },
+        ],
+        person: { id: 2, name: "Person 2" },
+      },
     ];
     expect(
-      attemptResultsWarning(attemptResults, "333fm", [], existingResults)
+      attemptResultsWarning(attemptResults, "333fm", [], existingResults),
     ).toEqual(null);
   });
 });


### PR DESCRIPTION
I saw this issue https://github.com/thewca/wca-live/issues/274 and thought I'd give it a try.

> It would be nice if there were a pop-up warning that the results that you entered are an exact match with existing results in the same round. Duplicate results typically happen when the person who entered the results for the wrong person by typoing their ID or selecting the wrong name by accident and overwrites existing results. Duplicate results are often overlooked when the duplicate results overwrite already-double-checked results.
>
> Exceptions would include FMC results and DNF results since ties are common under these circumstances.

<img width="1257" alt="Screenshot 2025-07-08 at 2 04 43 PM" src="https://github.com/user-attachments/assets/1b40362f-9049-4bce-99e6-5f420894adc5" />


### ~~Breaking change~~

~~In order to check for duplicate results in the current stored batch, I changed the format of the stored batch results in localStorage to include the `person` attribute.  I figured that made more sense than fetching it each time, since theoretically this should affect few people (only data batches which are in-progress before deployment and need to be refreshed after); but maybe this is a rare enough case that it's better not to introduce a breaking change.  What do you think?~~

Removed after discussion, in favor of creating a `combinedResults` array