### PR TITLE
Change light green to an arbitrary light yellow

### DIFF
--- a/client/src/components/CompetitorResults/CompetitorResultsTable.jsx
+++ b/client/src/components/CompetitorResults/CompetitorResultsTable.jsx
@@ -9,8 +9,7 @@ import {
   Paper,
   useMediaQuery,
 } from "@mui/material";
-import { green } from "@mui/material/colors";
-import { alpha } from "@mui/material/styles";
+import { yellow, green } from "@mui/material/colors";
 import { times } from "../../lib/utils";
 import { formatAttemptResult } from "../../lib/attempt-result";
 import { orderedResultStats, paddedAttemptResults } from "../../lib/result";
@@ -26,8 +25,8 @@ const styles = {
     backgroundColor: green["A400"],
   },
   advancingQuestionable: {
-    color: (theme) => theme.palette.getContrastText(alpha(green["A400"], 0.5)),
-    backgroundColor: alpha(green["A400"], 0.5),
+    color: (theme) => theme.palette.getContrastText(yellow["200"]),
+    backgroundColor: yellow["200"],
   },
   roundName: {
     width: { xs: 150, lg: 200 },

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -15,8 +15,7 @@ import {
   Toolbar,
   Typography,
 } from "@mui/material";
-import { green } from "@mui/material/colors";
-import { alpha } from "@mui/material/styles";
+import { yellow, green } from "@mui/material/colors";
 import PauseIcon from "@mui/icons-material/Pause";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import CloseIcon from "@mui/icons-material/Close";
@@ -48,8 +47,8 @@ const styles = {
     backgroundColor: green["A400"],
   },
   advancingQuestionable: {
-    color: (theme) => theme.palette.getContrastText(alpha(green["A400"], 0.5)),
-    backgroundColor: alpha(green["A400"], 0.5),
+    color: (theme) => theme.palette.getContrastText(yellow["200"]),
+    backgroundColor: yellow["200"],
   },
   name: {
     width: "22%",

--- a/client/src/components/RoundResults/RoundResultsTable.jsx
+++ b/client/src/components/RoundResults/RoundResultsTable.jsx
@@ -10,8 +10,7 @@ import {
   Paper,
   useMediaQuery,
 } from "@mui/material";
-import { green } from "@mui/material/colors";
-import { alpha } from "@mui/material/styles";
+import { yellow, green } from "@mui/material/colors";
 import { times } from "../../lib/utils";
 import { formatAttemptResult } from "../../lib/attempt-result";
 import { orderedResultStats, paddedAttemptResults } from "../../lib/result";
@@ -35,8 +34,8 @@ const styles = {
     backgroundColor: green["A400"],
   },
   advancingQuestionable: {
-    color: (theme) => theme.palette.getContrastText(alpha(green["A400"], 0.5)),
-    backgroundColor: alpha(green["A400"], 0.5),
+    color: (theme) => theme.palette.getContrastText(yellow["200"]),
+    backgroundColor: yellow["200"],
   },
   name: {
     textOverflow: "ellipsis",

--- a/client/src/components/admin/AdminRound/AdminResultsTable.jsx
+++ b/client/src/components/admin/AdminRound/AdminResultsTable.jsx
@@ -9,8 +9,7 @@ import {
   Tooltip,
 } from "@mui/material";
 import EmojiPeopleIcon from "@mui/icons-material/EmojiPeople";
-import { green } from "@mui/material/colors";
-import { alpha } from "@mui/material/styles";
+import { yellow, green } from "@mui/material/colors";
 import { times } from "../../../lib/utils";
 import { formatAttemptResult } from "../../../lib/attempt-result";
 import { orderedResultStats, paddedAttemptResults } from "../../../lib/result";
@@ -27,8 +26,8 @@ const styles = {
     backgroundColor: green["A400"],
   },
   advancingQuestionable: {
-    color: (theme) => theme.palette.getContrastText(alpha(green["A400"], 0.5)),
-    backgroundColor: alpha(green["A400"], 0.5),
+    color: (theme) => theme.palette.getContrastText(yellow["200"]),
+    backgroundColor: yellow["200"],
   },
 };
 


### PR DESCRIPTION
This only changes the color of `advancingQuestionable` from `alpha(green["A400"], 0.5)` to `yellow["200"]`.

<img width="300" alt="Screenshot 2025-07-12 at 10 56 20 PM" src="https://github.com/user-attachments/assets/dc0d95e1-b6b6-49c8-be1b-613c0ebde773" />
<img width="400" alt="Screenshot 2025-07-12 at 10 59 47 PM" src="https://github.com/user-attachments/assets/cbed9875-3bd4-43a2-8e36-a56f412e1f45" />

Refs https://github.com/thewca/wca-live/issues/276

See the MUI color palette for more on the default color options: https://mui.com/material-ui/customization/color/#color-palette  (Note that we're currently using green's A400 as the advancing color.)
