### PR TITLE
Display entered_by only in the double check view

### DIFF
--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -53,7 +53,7 @@ function ResultAttemptsForm({
     setAttemptResults(
       result
         ? paddedAttemptResults(result, numberOfAttempts)
-        : defaultAttemptResults,
+        : defaultAttemptResults
     );
   }, [result, numberOfAttempts, defaultAttemptResults]);
 
@@ -82,7 +82,7 @@ function ResultAttemptsForm({
   function handleAttemptResultChange(index, value) {
     const newAttemptResults = setAt(attemptResults, index, value);
     setAttemptResults(
-      applyCutoff(applyTimeLimit(newAttemptResults, timeLimit), cutoff),
+      applyCutoff(applyTimeLimit(newAttemptResults, timeLimit), cutoff)
     );
   }
 
@@ -99,7 +99,7 @@ function ResultAttemptsForm({
     const submissionWarning = attemptResultsWarning(
       attemptResults,
       eventId,
-      officialWorldRecords,
+      officialWorldRecords
     );
 
     if (submissionWarning) {
@@ -173,9 +173,11 @@ function ResultAttemptsForm({
         )}
       </Grid>
       <Grid item>
-        <Typography variant="body2" color="textSecondary">
-          {`Updated by: ${result.enteredBy.name}`}
-        </Typography>
+        {result?.enteredBy && (
+          <Typography variant="body2" color="textSecondary">
+            {`Updated by: ${result.enteredBy.name}`}
+          </Typography>
+        )}
       </Grid>
       <Grid item container alignItems="flex-end">
         <Grid item>

--- a/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
+++ b/client/src/components/admin/ResultAttemptsForm/ResultAttemptsForm.jsx
@@ -53,7 +53,7 @@ function ResultAttemptsForm({
     setAttemptResults(
       result
         ? paddedAttemptResults(result, numberOfAttempts)
-        : defaultAttemptResults
+        : defaultAttemptResults,
     );
   }, [result, numberOfAttempts, defaultAttemptResults]);
 
@@ -82,7 +82,7 @@ function ResultAttemptsForm({
   function handleAttemptResultChange(index, value) {
     const newAttemptResults = setAt(attemptResults, index, value);
     setAttemptResults(
-      applyCutoff(applyTimeLimit(newAttemptResults, timeLimit), cutoff)
+      applyCutoff(applyTimeLimit(newAttemptResults, timeLimit), cutoff),
     );
   }
 
@@ -99,7 +99,7 @@ function ResultAttemptsForm({
     const submissionWarning = attemptResultsWarning(
       attemptResults,
       eventId,
-      officialWorldRecords
+      officialWorldRecords,
     );
 
     if (submissionWarning) {


### PR DESCRIPTION
After merging #289 I checked one of my comps on prod and noticed that the admin round page goes blank, because `enteredBy` is null. It happens, because we don't fetch enteredBy in this view - as it's not needed. I added the check for its presence, which fixes the issue.