### PR TITLE
Allow user to filter by scoretaker when double checking

### DIFF
--- a/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
+++ b/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
@@ -217,33 +217,35 @@ function RoundDoubleCheck() {
           </IconButton>
         </Grid>
         <Grid item md={3}>
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <InputLabel id="scoretaker-filter-label">
-              Filter Scoretaker
-            </InputLabel>
-            <Select
-              labelId="scoretaker-filter-label"
-              id="scoretaker-filter"
-              value={scoretakerFilter}
-              label="Filter Scoretaker"
-              onChange={(event) => {
-                updateScoretakerFilter(event.target.value);
-                updateResultIndex(0);
-                setTimeout(() => {
-                  rightButtonRef.current.focus();
-                }, 0);
-              }}
-            >
-              <MenuItem value={""}>
-                <em>All</em>
-              </MenuItem>
-              {scoreTakerNames.map((name) => (
-                <MenuItem key={name} value={name}>
-                  {name}
+          {scoreTakerNames.length > 1 && (
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <InputLabel id="scoretaker-filter-label">
+                Filter Scoretaker
+              </InputLabel>
+              <Select
+                labelId="scoretaker-filter-label"
+                id="scoretaker-filter"
+                value={scoretakerFilter}
+                label="Filter Scoretaker"
+                onChange={(event) => {
+                  updateScoretakerFilter(event.target.value);
+                  updateResultIndex(0);
+                  setTimeout(() => {
+                    // rightButtonRef.current.focus();
+                  }, 0);
+                }}
+              >
+                <MenuItem value={""}>
+                  <em>All</em>
                 </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+                {scoreTakerNames.map((name) => (
+                  <MenuItem key={name} value={name}>
+                    {name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
           <ResultAttemptsForm
             result={results[resultIndex]}
             results={round.results}

--- a/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
+++ b/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
@@ -116,7 +116,7 @@ function RoundDoubleCheck() {
   const filteredResults =
     data?.round.results.filter((result) => {
       if (!scoretakerFilter || scoretakerFilter === "0") return true;
-      return result.enteredBy.name === scoretakerFilter;
+      return result.enteredBy?.name === scoretakerFilter;
     }) || [];
 
   const [enterResults, { error: enterLoading }] = useMutation(

--- a/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
+++ b/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
@@ -58,6 +58,7 @@ const ROUND_QUERY = gql`
         }
         enteredAt
         enteredBy {
+          id
           name
         }
       }
@@ -116,7 +117,7 @@ function RoundDoubleCheck() {
   const unfilteredResults = data?.round.results || [];
   const filteredResults = scoretakerFilter
     ? unfilteredResults.filter((result) => {
-        return result.enteredBy?.name === scoretakerFilter;
+        return result.enteredBy?.id === scoretakerFilter;
       })
     : unfilteredResults;
 
@@ -147,14 +148,14 @@ function RoundDoubleCheck() {
   if (error) return <Error error={error} />;
   const { round, officialWorldRecords } = data;
 
-  const scoreTakerNames = [
-    ...round.results.reduce((acc, result) => {
-      if (result.enteredBy?.name) {
-        acc.add(result.enteredBy.name);
+  const scoretakers = Object.values(
+    round.results.reduce((acc, result) => {
+      if (result.enteredBy) {
+        acc[result.enteredBy.id] = result.enteredBy;
       }
       return acc;
-    }, new Set()),
-  ].sort((a, b) => a.localeCompare(b));
+    }, {}),
+  ).sort((a, b) => a.name.localeCompare(b.name));
 
   const results = orderBy(
     filteredResults,
@@ -218,7 +219,7 @@ function RoundDoubleCheck() {
           </IconButton>
         </Grid>
         <Grid item md={3}>
-          {scoreTakerNames.length > 1 && (
+          {scoretakers.length > 1 && (
             <FormControl fullWidth sx={{ mb: 2 }}>
               <InputLabel id="scoretaker-filter-label">
                 Filter Scoretaker
@@ -236,9 +237,9 @@ function RoundDoubleCheck() {
                 <MenuItem value={""}>
                   <em>All</em>
                 </MenuItem>
-                {scoreTakerNames.map((name) => (
-                  <MenuItem key={name} value={name}>
-                    {name}
+                {scoretakers.map((scoretaker) => (
+                  <MenuItem key={scoretaker.id} value={scoretaker.id}>
+                    {scoretaker.name}
                   </MenuItem>
                 ))}
               </Select>

--- a/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
+++ b/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
@@ -148,7 +148,9 @@ function RoundDoubleCheck() {
 
   const scoreTakerNames = [
     ...round.results.reduce((acc, result) => {
-      acc.add(result.enteredBy.name);
+      if (result.enteredBy?.name) {
+        acc.add(result.enteredBy.name);
+      }
       return acc;
     }, new Set()),
   ].sort((a, b) => a.localeCompare(b));

--- a/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
+++ b/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
@@ -113,11 +113,12 @@ function RoundDoubleCheck() {
     variables: { id: roundId },
   });
 
-  const filteredResults =
-    data?.round.results.filter((result) => {
-      if (!scoretakerFilter || scoretakerFilter === "0") return true;
-      return result.enteredBy?.name === scoretakerFilter;
-    }) || [];
+  const unfilteredResults = data?.round.results || [];
+  const filteredResults = scoretakerFilter
+    ? unfilteredResults.filter((result) => {
+        return result.enteredBy?.name === scoretakerFilter;
+      })
+    : unfilteredResults;
 
   const [enterResults, { error: enterLoading }] = useMutation(
     ENTER_RESULT_ATTEMPTS,

--- a/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
+++ b/client/src/components/admin/RoundDoubleCheck/RoundDoubleCheck.jsx
@@ -230,9 +230,6 @@ function RoundDoubleCheck() {
                 onChange={(event) => {
                   updateScoretakerFilter(event.target.value);
                   updateResultIndex(0);
-                  setTimeout(() => {
-                    // rightButtonRef.current.focus();
-                  }, 0);
                 }}
               >
                 <MenuItem value={""}>


### PR DESCRIPTION
In issue https://github.com/thewca/wca-live/issues/133, a suggested solution was:
> But I think a better approach could be having a select where you pick the scoretaker and it shows the results they entered (and the select defaults to "All").

The scoretaker filter only appears when there is more than one scoretaker.

<img width="1860" height="934" alt="image" src="https://github.com/user-attachments/assets/6592e065-8654-4e21-be7b-47cc06d11d72" />
<img width="507" height="706" alt="image" src="https://github.com/user-attachments/assets/781ac314-902b-448e-9d55-1f3b004c8c9e" />
<img width="494" height="693" alt="image" src="https://github.com/user-attachments/assets/75d5921d-6f13-4eda-a423-a20bd8eab5ee" />