### PR TITLE
Prevent automatic browser translation of competitor names (#305)

### DIFF
--- a/client/src/components/Competitor/Competitor.jsx
+++ b/client/src/components/Competitor/Competitor.jsx
@@ -68,7 +68,8 @@ function Competitor() {
       <Grid container alignContent="center" sx={{ mb: 2 }}>
         <Grid item>
           <Typography variant="h5">
-            {person.name} <FlagIcon code={person.country.iso2.toLowerCase()} />
+            <span translate="no">{person.name}</span>{" "}
+            <FlagIcon code={person.country.iso2.toLowerCase()} />
           </Typography>
         </Grid>
         <Grid item sx={{ flexGrow: 1 }} />

--- a/client/src/components/Competitors/CompetitorList.jsx
+++ b/client/src/components/Competitors/CompetitorList.jsx
@@ -61,7 +61,9 @@ function CompetitorList({ competitors, competitionId }) {
                   size="lg"
                 />
               </ListItemIcon>
-              <ListItemText primary={competitor.name} />
+              <ListItemText
+                primary={<span translate="no">{competitor.name}</span>}
+              />
             </ListItemButton>
           ))}
         </List>

--- a/client/src/components/RecordList/RecordList.jsx
+++ b/client/src/components/RecordList/RecordList.jsx
@@ -41,7 +41,12 @@ function RecordList({ title, records }) {
                   </Box>
                 </span>
               }
-              secondary={`${record.result.person.name} from ${record.result.person.country.name}`}
+              secondary={
+                <>
+                  <span translate="no">{record.result.person.name}</span> from{" "}
+                  {record.result.person.country.name}
+                </>
+              }
             />
           </ListItemButton>
         ))}

--- a/client/src/components/ResultsProjector/ResultsProjector.jsx
+++ b/client/src/components/ResultsProjector/ResultsProjector.jsx
@@ -268,7 +268,10 @@ function ResultsProjector({
                     >
                       {result.ranking}
                     </TableCell>
-                    <TableCell sx={{ ...styles.cell, ...styles.name }}>
+                    <TableCell
+                      sx={{ ...styles.cell, ...styles.name }}
+                      translate="no"
+                    >
                       {result.person.name}
                     </TableCell>
                     <TableCell sx={styles.cell} align="center">

--- a/client/src/components/RoundResults/RoundResultDialog.jsx
+++ b/client/src/components/RoundResults/RoundResultDialog.jsx
@@ -35,13 +35,16 @@ function RoundResultDialog({
       {!!result && (
         <>
           <DialogTitle>
-            {result.person.name} {result.ranking && `#${result.ranking}`}
+            <span translate="no">{result.person.name}</span>{" "}
+            {result.ranking && `#${result.ranking}`}
           </DialogTitle>
           <DialogContent>
             <Grid container direction="column" spacing={2}>
               <Grid item>
                 <Typography variant="subtitle2">Name</Typography>
-                <Typography variant="body2">{result.person.name}</Typography>
+                <Typography variant="body2" translate="no">
+                  {result.person.name}
+                </Typography>
                 <Link
                   component={RouterLink}
                   to={`/competitions/${competitionId}/competitors/${result.person.id}`}

--- a/client/src/components/RoundResults/RoundResultsTable.jsx
+++ b/client/src/components/RoundResults/RoundResultsTable.jsx
@@ -116,7 +116,10 @@ const RoundResultsTable = memo(
                 >
                   {result.ranking}
                 </TableCell>
-                <TableCell sx={{ ...styles.cell, ...styles.name }}>
+                <TableCell
+                  sx={{ ...styles.cell, ...styles.name }}
+                  translate="no"
+                >
                   {smScreen ? (
                     <Link
                       component={RouterLink}

--- a/client/src/components/admin/AdminCompetitors/AdminCompetitorsTable.jsx
+++ b/client/src/components/admin/AdminCompetitors/AdminCompetitorsTable.jsx
@@ -103,7 +103,7 @@ const AdminCompetitorsTable = memo(
                   }}
                 >
                   <TableCell align="right">{person.registrantId}</TableCell>
-                  <TableCell>
+                  <TableCell translate="no">
                     <Link
                       component={RouterLink}
                       to={`/competitions/${competitionId}/competitors/${person.id}`}

--- a/client/src/components/admin/AdminRound/AdminResultsTable.jsx
+++ b/client/src/components/admin/AdminRound/AdminResultsTable.jsx
@@ -137,7 +137,7 @@ const AdminResultsTable = memo(
               <TableCell align="right">{result.person.registrantId}</TableCell>
               <TableCell>
                 <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-                  <div>{result.person.name}</div>
+                  <div translate="no">{result.person.name}</div>
                   {!result.person.wcaId && (
                     <div style={{ display: "flex" }}>
                       <Tooltip title="Newcomer" placement="right">

--- a/client/src/components/admin/AdminRound/QuitCompetitorDialog.jsx
+++ b/client/src/components/admin/AdminRound/QuitCompetitorDialog.jsx
@@ -79,8 +79,7 @@ const QuitCompetitorDialog = ({ open, onClose, competitor, roundId }) => {
     <Dialog open={open} onClose={onClose}>
       {loading && <Loading />}
       <DialogTitle>
-        Quit{" "}
-        <span translate="no">{competitor && competitor.name}</span>
+        Quit <span translate="no">{competitor && competitor.name}</span>
       </DialogTitle>
       <DialogContent>
         {error && <Error error={error} />}

--- a/client/src/components/admin/AdminRound/QuitCompetitorDialog.jsx
+++ b/client/src/components/admin/AdminRound/QuitCompetitorDialog.jsx
@@ -79,14 +79,16 @@ const QuitCompetitorDialog = ({ open, onClose, competitor, roundId }) => {
     <Dialog open={open} onClose={onClose}>
       {loading && <Loading />}
       <DialogTitle>
-        Quit {competitor && competitor && competitor.name}
+        Quit{" "}
+        <span translate="no">{competitor && competitor.name}</span>
       </DialogTitle>
       <DialogContent>
         {error && <Error error={error} />}
         {data && (
           <>
             <DialogContentText>
-              Going to permanently remove {competitor && competitor.name} from
+              Going to permanently remove{" "}
+              <span translate="no">{competitor && competitor.name}</span> from
               this round. Are you sure you want to proceed?
             </DialogContentText>
             <RadioGroup
@@ -97,24 +99,44 @@ const QuitCompetitorDialog = ({ open, onClose, competitor, roundId }) => {
                 <FormControlLabel
                   control={<Radio />}
                   value="yes"
-                  label={`
-                    Yes, remove ${competitor && competitor.name}
-                    and replace them with other qualifying competitors:
-                    ${data.round.nextQualifying
-                      .map(({ name }) => name)
-                      .join(", ")}.
-                  `}
+                  label={
+                    <>
+                      Yes, remove{" "}
+                      <span translate="no">
+                        {competitor && competitor.name}
+                      </span>{" "}
+                      and replace them with other qualifying competitors:{" "}
+                      <span translate="no">
+                        {data.round.nextQualifying
+                          .map(({ name }) => name)
+                          .join(", ")}
+                      </span>
+                      .
+                    </>
+                  }
                 />
               )}
               <FormControlLabel
                 control={<Radio />}
                 value="no"
                 label={
-                  data.round.nextQualifying.length > 0
-                    ? `Yes, just remove ${
-                        competitor && competitor.name
-                      } and don't replace them.`
-                    : `Yes, remove ${competitor && competitor.name}.`
+                  data.round.nextQualifying.length > 0 ? (
+                    <>
+                      Yes, just remove{" "}
+                      <span translate="no">
+                        {competitor && competitor.name}
+                      </span>{" "}
+                      and don't replace them.
+                    </>
+                  ) : (
+                    <>
+                      Yes, remove{" "}
+                      <span translate="no">
+                        {competitor && competitor.name}
+                      </span>
+                      .
+                    </>
+                  )
                 }
               />
             </RadioGroup>

--- a/client/src/components/admin/AdminRound/ResultMenu.jsx
+++ b/client/src/components/admin/AdminRound/ResultMenu.jsx
@@ -35,10 +35,7 @@ function ResultMenu({
         transformOrigin={{ vertical: 0, horizontal: "center" }}
         MenuListProps={{
           subheader: (
-            <ListSubheader
-              sx={{ backgroundColor: "inherit" }}
-              translate="no"
-            >
+            <ListSubheader sx={{ backgroundColor: "inherit" }} translate="no">
               {result && result.person.name}
             </ListSubheader>
           ),

--- a/client/src/components/admin/AdminRound/ResultMenu.jsx
+++ b/client/src/components/admin/AdminRound/ResultMenu.jsx
@@ -35,7 +35,10 @@ function ResultMenu({
         transformOrigin={{ vertical: 0, horizontal: "center" }}
         MenuListProps={{
           subheader: (
-            <ListSubheader sx={{ backgroundColor: "inherit" }}>
+            <ListSubheader
+              sx={{ backgroundColor: "inherit" }}
+              translate="no"
+            >
               {result && result.person.name}
             </ListSubheader>
           ),

--- a/client/src/components/admin/PersonSelect/PersonSelect.jsx
+++ b/client/src/components/admin/PersonSelect/PersonSelect.jsx
@@ -49,6 +49,11 @@ function PersonSelect({
       filterOptions={(persons, { inputValue }) =>
         searchPersons(persons, inputValue)
       }
+      renderOption={(props, person) => (
+        <li {...props} key={person.id} translate="no">
+          {personToLabel(person)}
+        </li>
+      )}
       renderInput={(params) => (
         <TextField
           {...params}


### PR DESCRIPTION
Fixes #305

### Summary of Changes
Added `translate="no"` attribute and `<span>` wrappers to competitor name variables across the application UI to prevent browser translation engines (like Google Translate) from hallucinating translations for proper nouns.

- **RoundResultDialog**: Added `translate="no"` to dialog title and name body field.
- **Competitor Page & Tables**: Added `translate="no"` to competitor profile headers, results tables (`RoundResultsTable`), list items (`CompetitorList`), projector views (`ResultsProjector`), and record entries (`RecordList`).
- **Admin Views**: Applied `translate="no"` across admin competitor tables, double-check forms, and dialogs.