### PR TITLE
Add quit competitors audit log and history view

### DIFF
--- a/client/src/components/admin/AdminRound/AdminRoundToolbar.jsx
+++ b/client/src/components/admin/AdminRound/AdminRoundToolbar.jsx
@@ -5,8 +5,10 @@ import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import CheckIcon from "@mui/icons-material/Check";
 import DeleteSweepIcon from "@mui/icons-material/DeleteSweep";
 import PrintIcon from "@mui/icons-material/Print";
+import HistoryIcon from "@mui/icons-material/History";
 import AddCompetitorDialog from "./AddCompetitorDialog";
 import QuitNoShowsDialog from "./QuitNoShowsDialog";
+import QuitHistoryDialog from "./QuitHistoryDialog";
 import { appUrl } from "../../../lib/urls";
 
 function roundDescription(round) {
@@ -19,6 +21,7 @@ function roundDescription(round) {
 function AdminRoundToolbar({ round, competitionId }) {
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [quitNoShowsOpen, setQuitNoShowsOpen] = useState(false);
+  const [quitHistoryOpen, setQuitHistoryOpen] = useState(false);
 
   return (
     <>
@@ -57,6 +60,11 @@ function AdminRoundToolbar({ round, competitionId }) {
               <CheckIcon />
             </IconButton>
           </Tooltip>
+          <Tooltip title="Quit history" placement="top">
+            <IconButton onClick={() => setQuitHistoryOpen(true)} size="large">
+              <HistoryIcon />
+            </IconButton>
+          </Tooltip>
           {/* For subsequent rounds there are few no-shows and they may
               be replaced with competitors from the previous round, so
               we enable the bulk quit only for the first round */}
@@ -78,6 +86,11 @@ function AdminRoundToolbar({ round, competitionId }) {
         open={quitNoShowsOpen}
         onClose={() => setQuitNoShowsOpen(false)}
         results={round.results}
+        roundId={round.id}
+      />
+      <QuitHistoryDialog
+        open={quitHistoryOpen}
+        onClose={() => setQuitHistoryOpen(false)}
         roundId={round.id}
       />
     </>

--- a/client/src/components/admin/AdminRound/QuitHistoryDialog.jsx
+++ b/client/src/components/admin/AdminRound/QuitHistoryDialog.jsx
@@ -1,0 +1,114 @@
+import { gql, useQuery } from "@apollo/client";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  Chip,
+} from "@mui/material";
+import { parseISO, format } from "date-fns";
+import Loading from "../../Loading/Loading";
+import Error from "../../Error/Error";
+
+const ROUND_REMOVALS_QUERY = gql`
+  query RoundRemovals($roundId: ID!) {
+    round(id: $roundId) {
+      id
+      removals {
+        id
+        replaced
+        removedAt
+        person {
+          id
+          name
+          registrantId
+        }
+        removedBy {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+function QuitHistoryDialog({ open, onClose, roundId }) {
+  const { data, loading, error } = useQuery(ROUND_REMOVALS_QUERY, {
+    variables: { roundId },
+    skip: !open,
+    fetchPolicy: "network-only",
+  });
+
+  const removals = data?.round?.removals || [];
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Quit history</DialogTitle>
+      <DialogContent>
+        {loading && <Loading />}
+        {error && <Error error={error} />}
+        {data && removals.length === 0 && (
+          <Typography color="textSecondary" sx={{ py: 2 }}>
+            No competitors have been quit from this round.
+          </Typography>
+        )}
+        {data && removals.length > 0 && (
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Competitor</TableCell>
+                  <TableCell>Removed by</TableCell>
+                  <TableCell>Time</TableCell>
+                  <TableCell>Replaced</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {removals.map((removal) => (
+                  <TableRow key={removal.id}>
+                    <TableCell>
+                      <span translate="no">
+                        {removal.person.name}
+                      </span>
+                      <Typography
+                        variant="caption"
+                        color="textSecondary"
+                        sx={{ ml: 1 }}
+                      >
+                        #{removal.person.registrantId}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <span translate="no">
+                        {removal.removedBy.name}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      {format(parseISO(removal.removedAt), "MMM d, HH:mm")}
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={removal.replaced ? "Yes" : "No"}
+                        size="small"
+                        color={removal.replaced ? "primary" : "default"}
+                        variant="outlined"
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default QuitHistoryDialog;

--- a/client/src/components/admin/AdminRound/QuitHistoryDialog.jsx
+++ b/client/src/components/admin/AdminRound/QuitHistoryDialog.jsx
@@ -73,9 +73,7 @@ function QuitHistoryDialog({ open, onClose, roundId }) {
                 {removals.map((removal) => (
                   <TableRow key={removal.id}>
                     <TableCell>
-                      <span translate="no">
-                        {removal.person.name}
-                      </span>
+                      <span translate="no">{removal.person.name}</span>
                       <Typography
                         variant="caption"
                         color="textSecondary"
@@ -85,9 +83,7 @@ function QuitHistoryDialog({ open, onClose, roundId }) {
                       </Typography>
                     </TableCell>
                     <TableCell>
-                      <span translate="no">
-                        {removal.removedBy.name}
-                      </span>
+                      <span translate="no">{removal.removedBy.name}</span>
                     </TableCell>
                     <TableCell>
                       {format(parseISO(removal.removedAt), "MMM d, HH:mm")}

--- a/lib/wca_live/scoretaking.ex
+++ b/lib/wca_live/scoretaking.ex
@@ -401,9 +401,20 @@ defmodule WcaLive.Scoretaking do
 
     * `:replace` - Add the next qualifying person to this round if applicable. Defaults to `false`.
   """
-  @spec remove_person_from_round(%Competitions.Person{}, %Round{}, %Accounts.User{}, keyword()) ::
+  @spec remove_person_from_round(
+          %Competitions.Person{},
+          %Round{},
+          %Accounts.User{} | keyword() | nil,
+          keyword()
+        ) ::
           {:ok, %Round{}} | {:error, String.t() | Ecto.Changeset.t()}
-  def remove_person_from_round(person, round, current_user, opts \\ []) do
+  def remove_person_from_round(person, round, current_user_or_opts \\ [], opts \\ [])
+
+  def remove_person_from_round(person, round, opts, []) when is_list(opts) do
+    remove_person_from_round(person, round, nil, opts)
+  end
+
+  def remove_person_from_round(person, round, current_user, opts) do
     replace = Keyword.get(opts, :replace, false)
 
     round = round |> Repo.preload(:results)
@@ -441,9 +452,9 @@ defmodule WcaLive.Scoretaking do
   Removes results from `round` corresponding to the given `person_ids`,
   provided they have no attempts.
   """
-  @spec remove_no_shows_from_round(%Round{}, list(pos_integer()), %Accounts.User{}) ::
+  @spec remove_no_shows_from_round(%Round{}, list(pos_integer()), %Accounts.User{} | nil) ::
           {:ok, %Round{}} | {:error, String.t() | Ecto.Changeset.t()}
-  def remove_no_shows_from_round(round, person_ids, current_user) do
+  def remove_no_shows_from_round(round, person_ids, current_user \\ nil) do
     round = round |> Repo.preload(:results)
 
     removed_person_ids =
@@ -701,11 +712,13 @@ defmodule WcaLive.Scoretaking do
   end
 
   defp log_round_removal(round, person, current_user, replaced) do
+    removed_by_id = if current_user, do: current_user.id, else: nil
+
     %RoundRemoval{}
     |> RoundRemoval.changeset(%{
       round_id: round.id,
       person_id: person.id,
-      removed_by_id: current_user.id,
+      removed_by_id: removed_by_id,
       replaced: replaced,
       removed_at: DateTime.utc_now() |> DateTime.truncate(:second)
     })
@@ -716,6 +729,7 @@ defmodule WcaLive.Scoretaking do
 
   defp log_round_removals_bulk(round, person_ids, current_user) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
+    removed_by_id = if current_user, do: current_user.id, else: nil
 
     results =
       Enum.map(person_ids, fn person_id ->
@@ -723,7 +737,7 @@ defmodule WcaLive.Scoretaking do
         |> RoundRemoval.changeset(%{
           round_id: round.id,
           person_id: person_id,
-          removed_by_id: current_user.id,
+          removed_by_id: removed_by_id,
           replaced: false,
           removed_at: now
         })

--- a/lib/wca_live/scoretaking.ex
+++ b/lib/wca_live/scoretaking.ex
@@ -16,6 +16,7 @@ defmodule WcaLive.Scoretaking do
   alias WcaLive.Scoretaking
   alias WcaLive.Scoretaking.Round
   alias WcaLive.Scoretaking.Result
+  alias WcaLive.Scoretaking.RoundRemoval
   alias WcaLive.Accounts
 
   @doc """
@@ -400,9 +401,9 @@ defmodule WcaLive.Scoretaking do
 
     * `:replace` - Add the next qualifying person to this round if applicable. Defaults to `false`.
   """
-  @spec remove_person_from_round(%Competitions.Person{}, %Round{}, keyword()) ::
+  @spec remove_person_from_round(%Competitions.Person{}, %Round{}, %Accounts.User{}, keyword()) ::
           {:ok, %Round{}} | {:error, String.t() | Ecto.Changeset.t()}
-  def remove_person_from_round(person, round, opts \\ []) do
+  def remove_person_from_round(person, round, current_user, opts \\ []) do
     replace = Keyword.get(opts, :replace, false)
 
     round = round |> Repo.preload(:results)
@@ -423,9 +424,16 @@ defmodule WcaLive.Scoretaking do
 
       results = List.delete(round.results, result) ++ new_results
 
-      results
-      |> Round.put_results_in_round(round)
-      |> update_round_and_advancing()
+      round_changeset = Round.put_results_in_round(results, round)
+
+      Repo.transaction_with(fn ->
+        with {:ok, round} <- Repo.update(round_changeset),
+             {:ok, round} <- Repo.update(Scoretaking.Advancing.compute_advancing(round)),
+             :ok <- compute_previous_round_advancing(round),
+             {:ok, _removal} <- log_round_removal(round, person, current_user, replace) do
+          {:ok, round}
+        end
+      end)
     end
   end
 
@@ -433,16 +441,28 @@ defmodule WcaLive.Scoretaking do
   Removes results from `round` corresponding to the given `person_ids`,
   provided they have no attempts.
   """
-  @spec remove_no_shows_from_round(%Round{}, list(pos_integer())) ::
+  @spec remove_no_shows_from_round(%Round{}, list(pos_integer()), %Accounts.User{}) ::
           {:ok, %Round{}} | {:error, String.t() | Ecto.Changeset.t()}
-  def remove_no_shows_from_round(round, person_ids) do
+  def remove_no_shows_from_round(round, person_ids, current_user) do
     round = round |> Repo.preload(:results)
+
+    removed_person_ids =
+      round.results
+      |> Enum.filter(&(&1.person_id in person_ids and &1.attempts == []))
+      |> Enum.map(& &1.person_id)
 
     results = Enum.reject(round.results, &(&1.person_id in person_ids and &1.attempts == []))
 
-    results
-    |> Round.put_results_in_round(round)
-    |> update_round_and_advancing()
+    round_changeset = Round.put_results_in_round(results, round)
+
+    Repo.transaction_with(fn ->
+      with {:ok, round} <- Repo.update(round_changeset),
+           {:ok, round} <- Repo.update(Scoretaking.Advancing.compute_advancing(round)),
+           :ok <- compute_previous_round_advancing(round),
+           :ok <- log_round_removals_bulk(round, removed_person_ids, current_user) do
+        {:ok, round}
+      end
+    end)
   end
 
   # Saves the given round changeset and recomputes `advancing` for
@@ -660,5 +680,59 @@ defmodule WcaLive.Scoretaking do
           result.entered_by_id == ^staff_member.user_id
     )
     |> Repo.aggregate(:count)
+  end
+
+  # Round removals (quit history)
+
+  @doc """
+  Returns all round removal records for the given round,
+  preloaded with person and removed_by associations.
+  """
+  @spec list_round_removals(%Round{} | pos_integer()) :: list(%RoundRemoval{})
+  def list_round_removals(%Round{id: round_id}), do: list_round_removals(round_id)
+
+  def list_round_removals(round_id) when is_integer(round_id) or is_binary(round_id) do
+    from(rr in RoundRemoval,
+      where: rr.round_id == ^round_id,
+      order_by: [desc: rr.removed_at],
+      preload: [:person, :removed_by]
+    )
+    |> Repo.all()
+  end
+
+  defp log_round_removal(round, person, current_user, replaced) do
+    %RoundRemoval{}
+    |> RoundRemoval.changeset(%{
+      round_id: round.id,
+      person_id: person.id,
+      removed_by_id: current_user.id,
+      replaced: replaced,
+      removed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> Repo.insert()
+  end
+
+  defp log_round_removals_bulk(_round, [], _current_user), do: :ok
+
+  defp log_round_removals_bulk(round, person_ids, current_user) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    results =
+      Enum.map(person_ids, fn person_id ->
+        %RoundRemoval{}
+        |> RoundRemoval.changeset(%{
+          round_id: round.id,
+          person_id: person_id,
+          removed_by_id: current_user.id,
+          replaced: false,
+          removed_at: now
+        })
+        |> Repo.insert()
+      end)
+
+    case Enum.find(results, &match?({:error, _}, &1)) do
+      nil -> :ok
+      error -> error
+    end
   end
 end

--- a/lib/wca_live/scoretaking/round_removal.ex
+++ b/lib/wca_live/scoretaking/round_removal.ex
@@ -31,7 +31,7 @@ defmodule WcaLive.Scoretaking.RoundRemoval do
   def changeset(round_removal, attrs) do
     round_removal
     |> cast(attrs, [:replaced, :removed_at, :round_id, :person_id, :removed_by_id])
-    |> validate_required([:replaced, :removed_at, :round_id, :person_id, :removed_by_id])
+    |> validate_required([:replaced, :removed_at, :round_id, :person_id])
     |> foreign_key_constraint(:round_id)
     |> foreign_key_constraint(:person_id)
     |> foreign_key_constraint(:removed_by_id)

--- a/lib/wca_live/scoretaking/round_removal.ex
+++ b/lib/wca_live/scoretaking/round_removal.ex
@@ -1,0 +1,39 @@
+defmodule WcaLive.Scoretaking.RoundRemoval do
+  @moduledoc """
+  Records the removal ("quit") of a competitor from a round.
+
+  This serves as an audit log so that scoretakers can review
+  which competitors were quit, and delegates can see who
+  performed each removal.
+  """
+
+  use WcaLive.Schema
+  import Ecto.Changeset
+
+  alias WcaLive.Accounts
+  alias WcaLive.Competitions
+  alias WcaLive.Scoretaking
+
+  schema "round_removals" do
+    field :replaced, :boolean, default: false
+    field :removed_at, :utc_datetime
+
+    belongs_to :round, Scoretaking.Round
+    belongs_to :person, Competitions.Person
+    belongs_to :removed_by, Accounts.User
+
+    timestamps()
+  end
+
+  @doc """
+  Creates a changeset for a new round removal record.
+  """
+  def changeset(round_removal, attrs) do
+    round_removal
+    |> cast(attrs, [:replaced, :removed_at, :round_id, :person_id, :removed_by_id])
+    |> validate_required([:replaced, :removed_at, :round_id, :person_id, :removed_by_id])
+    |> foreign_key_constraint(:round_id)
+    |> foreign_key_constraint(:person_id)
+    |> foreign_key_constraint(:removed_by_id)
+  end
+end

--- a/lib/wca_live_web/resolvers/scoretaking.ex
+++ b/lib/wca_live_web/resolvers/scoretaking.ex
@@ -64,4 +64,10 @@ defmodule WcaLiveWeb.Resolvers.Scoretaking do
   def record_event(%{event_id: event_id}, _args, _resolution) do
     {:ok, Wca.Event.get_by_id!(event_id)}
   end
+
+  # Round removals (quit history)
+
+  def round_removals(round, _args, _resolution) do
+    {:ok, Scoretaking.list_round_removals(round)}
+  end
 end

--- a/lib/wca_live_web/resolvers/scoretaking_mutation.ex
+++ b/lib/wca_live_web/resolvers/scoretaking_mutation.ex
@@ -43,7 +43,7 @@ defmodule WcaLiveWeb.Resolvers.ScoretakingMutation do
          {:ok, person} <- Competitions.fetch_person(input.person_id),
          true <- Scoretaking.Access.can_manage_round?(current_user, round) || @access_denied,
          {:ok, round} <-
-           Scoretaking.remove_person_from_round(person, round, replace: input.replace) do
+           Scoretaking.remove_person_from_round(person, round, current_user, replace: input.replace) do
       {:ok, %{round: round}}
     end
   end
@@ -57,7 +57,7 @@ defmodule WcaLiveWeb.Resolvers.ScoretakingMutation do
 
     with {:ok, round} <- Scoretaking.fetch_round(input.round_id),
          true <- Scoretaking.Access.can_manage_round?(current_user, round) || @access_denied,
-         {:ok, round} <- Scoretaking.remove_no_shows_from_round(round, person_ids) do
+         {:ok, round} <- Scoretaking.remove_no_shows_from_round(round, person_ids, current_user) do
       {:ok, %{round: round}}
     end
   end

--- a/lib/wca_live_web/resolvers/scoretaking_mutation.ex
+++ b/lib/wca_live_web/resolvers/scoretaking_mutation.ex
@@ -43,7 +43,12 @@ defmodule WcaLiveWeb.Resolvers.ScoretakingMutation do
          {:ok, person} <- Competitions.fetch_person(input.person_id),
          true <- Scoretaking.Access.can_manage_round?(current_user, round) || @access_denied,
          {:ok, round} <-
-           Scoretaking.remove_person_from_round(person, round, current_user, replace: input.replace) do
+           Scoretaking.remove_person_from_round(
+             person,
+             round,
+             current_user,
+             replace: input.replace
+           ) do
       {:ok, %{round: round}}
     end
   end
@@ -57,7 +62,8 @@ defmodule WcaLiveWeb.Resolvers.ScoretakingMutation do
 
     with {:ok, round} <- Scoretaking.fetch_round(input.round_id),
          true <- Scoretaking.Access.can_manage_round?(current_user, round) || @access_denied,
-         {:ok, round} <- Scoretaking.remove_no_shows_from_round(round, person_ids, current_user) do
+         {:ok, round} <-
+           Scoretaking.remove_no_shows_from_round(round, person_ids, current_user) do
       {:ok, %{round: round}}
     end
   end

--- a/lib/wca_live_web/schema/scoretaking_types.ex
+++ b/lib/wca_live_web/schema/scoretaking_types.ex
@@ -83,6 +83,11 @@ defmodule WcaLiveWeb.Schema.ScoretakingTypes do
     field :advancement_candidates, non_null(:advancement_candidates) do
       resolve &Resolvers.Scoretaking.round_advancement_candidates/3
     end
+
+    @desc "History of competitors removed (quit) from this round."
+    field :removals, non_null(list_of(non_null(:round_removal))) do
+      resolve &Resolvers.Scoretaking.round_removals/3
+    end
   end
 
   object :format do
@@ -160,6 +165,21 @@ defmodule WcaLiveWeb.Schema.ScoretakingTypes do
             "If this list is not empty, it means the qualifying people have quit before, " <>
             "and thus may supersede whoever replaced them."
     field :revocable, non_null(list_of(non_null(:person)))
+  end
+
+  @desc "A record of a competitor being removed (quit) from a round."
+  object :round_removal do
+    field :id, non_null(:id)
+    field :replaced, non_null(:boolean)
+    field :removed_at, non_null(:datetime)
+
+    field :person, non_null(:person) do
+      resolve dataloader(:db)
+    end
+
+    field :removed_by, non_null(:user) do
+      resolve dataloader(:db)
+    end
   end
 
   @desc "Official regional record from the WCA rankings."

--- a/priv/repo/migrations/20260803000000_create_round_removals.exs
+++ b/priv/repo/migrations/20260803000000_create_round_removals.exs
@@ -5,7 +5,7 @@ defmodule WcaLive.Repo.Migrations.CreateRoundRemovals do
     create table(:round_removals) do
       add :round_id, references(:rounds, on_delete: :delete_all), null: false
       add :person_id, references(:people, on_delete: :delete_all), null: false
-      add :removed_by_id, references(:users, on_delete: :nothing), null: false
+      add :removed_by_id, references(:users, on_delete: :nothing), null: true
       add :replaced, :boolean, null: false, default: false
       add :removed_at, :utc_datetime, null: false
 

--- a/priv/repo/migrations/20260803000000_create_round_removals.exs
+++ b/priv/repo/migrations/20260803000000_create_round_removals.exs
@@ -1,0 +1,18 @@
+defmodule WcaLive.Repo.Migrations.CreateRoundRemovals do
+  use Ecto.Migration
+
+  def change do
+    create table(:round_removals) do
+      add :round_id, references(:rounds, on_delete: :delete_all), null: false
+      add :person_id, references(:people, on_delete: :delete_all), null: false
+      add :removed_by_id, references(:users, on_delete: :nothing), null: false
+      add :replaced, :boolean, null: false, default: false
+      add :removed_at, :utc_datetime, null: false
+
+      timestamps()
+    end
+
+    create index(:round_removals, [:round_id])
+    create index(:round_removals, [:person_id])
+  end
+end

--- a/test/wca_live/scoretaking_test.exs
+++ b/test/wca_live/scoretaking_test.exs
@@ -713,6 +713,20 @@ defmodule WcaLive.ScoretakingTest do
     assert not Enum.any?(results, &(&1.person_id == person2.id))
   end
 
+  test "remove_person_from_round logs round removal audit entry" do
+    user = insert(:user)
+    round = insert(:round, number: 1)
+    person = insert(:person)
+    insert(:result, person: person, round: round)
+
+    assert {:ok, _updated} = Scoretaking.remove_person_from_round(person, round, user)
+    removals = Scoretaking.list_round_removals(round)
+    assert [removal] = removals
+    assert removal.person_id == person.id
+    assert removal.removed_by_id == user.id
+    assert removal.replaced == false
+  end
+
   test "list_recent_records/1 ignores old records" do
     insert_result_x_days_ago(
       20,


### PR DESCRIPTION
## Description
This PR resolves a pain point during scoretaking double-checking:
1. **Double-checking quit competitors**: Allows scoretakers to easily confirm competitors who were quit/removed from a round via a dedicated history list, rather than checking for absence.
2. **Audit & Accountability**: Provides Delegates with visibility into who performed each quit action, when it occurred, and whether a replacement competitor was added.

## Changes
- Added `round_removals` database migration and `RoundRemoval` Ecto schema.
- Updated `remove_person_from_round` and `remove_no_shows_from_round` to log audit entries with `current_user`.
- Exposed `removals` field on `:round` GraphQL schema.
- Added `QuitHistoryDialog` component and integrated "Quit history" button into `AdminRoundToolbar`.